### PR TITLE
Fix cors

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -3,7 +3,11 @@
 Installation
 ############
 
-The latest official release of KubePortal is always available as `Docker image <https://hub.docker.com/r/troeger/kubeportal/>`__. The software is configured through environment variables (see :ref:`Configuration options`). It is mandatory to configure at least one authentication method (``KUBEPORTAL_AUTH_...``) and a database  ``KUBEPORTAL_DATABASE_URL`` .
+The latest official release of KubePortal is always available as `Docker image <https://hub.docker.com/r/troeger/kubeportal/>`__. The software is configured through environment variables (see :ref:`Configuration options`). 
+
+It is *mandatory* to configure the public URLs used by the installation ``KUBEPORTAL_ALLOWED_URLS``.
+
+It is *highly recommended* to configure at least one authentication method (``KUBEPORTAL_AUTH_...``) and the database storage.
 
 KubePortal is expected to run inside the Kubernetes cluster it acts as frontend for. The API server is auto-detected from the pod running the software. Permissions must be given to the KubePortal namespace for allowing it to create new namespaces.
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -60,6 +60,7 @@ KUBEPORTAL_API_SERVER_EXTERNAL        URL of the Kubernetes API server that work
 KUBEPORTAL_SESSION_COOKIE_DOMAIN      The domain used for the user session cookie, e.g. ``.example.com``.
 KUBEPORTAL_NAMESPACE_CLUSTERROLES     Kubernetes cluster roles that should be bound to the *default* service account of newly created Kubernetes namespaces, e.g. ``minimal-api,standard-api``.
 KUBEPORTAL_BRANDING                   The human-readable name of your cluster.
+KUBEPORTAL_ALLOWED_URLS               The portal URLs used by clients, eg. ``https://portal.foo.com:8000,http://example.com``. This is crucial for browser security headers, such as CORS.
 KUBEPORTAL_LANGUAGE_CODE              The locale for the web site, e.g. ``en-us``.
 KUBEPORTAL_TIME_ZONE                  The time zone for the web site, e.g. ``UTC``.
 KUBEPORTAL_ADMIN_NAME                 The name of the superuser, used only for email sending.

--- a/kubeportal/middleware.py
+++ b/kubeportal/middleware.py
@@ -1,6 +1,11 @@
 from django.http import Http404
 from django.shortcuts import redirect
 from django.urls import reverse
+from kubeportal import settings
+import logging
+
+logger = logging.getLogger('KubePortal')
+
 
 class HideAdminForNonStaffMiddleware:
     '''
@@ -25,3 +30,64 @@ class HideAdminForNonStaffMiddleware:
                     raise Http404()
 
         return self.get_response(request)
+
+
+class CorsMiddleware:
+    '''
+    After spending endless hours fighting CORS with Kat-Hi,
+    this is our final solution.
+    We gave up on half-broken libraries for this issue.
+
+    The list of valid origins is set with the KUBEPORTAL_ALLOWED_URLS
+    environment variable.
+    They need to match with the HTTP request header 'Origin' generated
+    by the JavaScript API call.
+
+    Please note that '*' is no longer an option for allowed origins:
+
+    https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#Credentialed_requests_and_wildcards
+
+    This middleware simply returns all needed headers with every response,
+    so that we no longer need to understand the difference between preflight
+    requests and the actual request.
+    '''
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
+
+        if not 'Origin' in request.headers:
+            # This is not a CORS-related request.
+            return response
+
+        origin = request.headers['Origin']
+        allowed_origins = settings.ALLOWED_URLS
+
+        if len(allowed_origins) == 0:
+            # Ok, the user forgot to configure KUBEPORTAL_ALLOWED_URLS.
+            if settings.DEBUG == True: 
+                # We call it the Kat-Hi mode. Just go on.
+                logger.warn("KUBEPORTAL_ALLOWED_URLS is not set. Overriding CORS due to DEBUG mode.")
+            else:
+                # Whitelist is missing, so no CORS headers are added to the response.
+                logger.error("KUBEPORTAL_ALLOWED_URLS is not set, so CORS origin check is not possible and the headers cannot be set. This will break JavaScript API calls.")
+                return response
+        else:
+            # Nice, we have a whitelist for origins
+            # We honor it, even in DEBUG mode, since the developer may try something here.
+            if not origin in allowed_origins:
+                # Given origin is not in the whitelist. This is an attack (0.00001%)
+                # or a misconfiguration (99.99999% probability).
+                #
+                # God, I hate security.
+                logger.error(f"Origin '{origin}' is not part of KUBEPORTAL_ALLOWED_URLS: {allowed_origins}. CORS headers cannot be set. This will break JavaScript API calls.")
+                return response
+
+        response["Access-Control-Allow-Origin"] = request.headers["Origin"]                    
+        response["Vary"] = "Origin"  # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin
+        response["Access-Control-Allow-Methods"] = "GET,HEAD,OPTIONS,POST,PUT"
+        response["Access-Control-Allow-Credentials"] = "true"
+        response["Access-Control-Allow-Headers"] = "Access-Control-Allow-Origin, Access-Control-Allow-Headers, Origin,Accept, X-Requested-With, Content-Type, Access-Control-Request-Method, Access-Control-Request-Headers"
+        return response

--- a/kubeportal/settings.py
+++ b/kubeportal/settings.py
@@ -22,7 +22,6 @@ class Common(Configuration):
         'django.contrib.sessions',
         'django.contrib.messages',
         'django.contrib.staticfiles',
-        'corsheaders',
         'sortedm2m_filter_horizontal_widget',
         'oidc_provider',
         'rest_framework',
@@ -42,7 +41,7 @@ class Common(Configuration):
 
     MIDDLEWARE = [
         'silk.middleware.SilkyMiddleware',
-        'corsheaders.middleware.CorsMiddleware',
+        'kubeportal.middleware.CorsMiddleware',
         'django.middleware.security.SecurityMiddleware',
         'django.contrib.sessions.middleware.SessionMiddleware',
         'django.middleware.common.CommonMiddleware',
@@ -139,13 +138,10 @@ class Common(Configuration):
     USE_L10N = True
     USE_TZ = True
 
+    # Allow frontend dev server addresses as default, so that dev mode
+    # works without an extra env variable being set
     ALLOWED_URLS = values.ListValue([], environ_prefix='KUBEPORTAL')
     ALLOWS_HOSTS = [urlparse(url).netloc for url in ALLOWED_URLS.value]
-    # Please note that '*' is no longer an option:
-    # https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#Credentialed_requests_and_wildcards
-    CORS_ALLOW_ALL_ORIGINS = False
-    CORS_ALLOW_CREDENTIALS = True
-    CORS_ALLOWED_ORIGINS = ALLOWED_URLS.value
 
     AUTH_USER_MODEL = 'kubeportal.User'
 

--- a/kubeportal/settings.py
+++ b/kubeportal/settings.py
@@ -20,6 +20,7 @@ class Common(Configuration):
         'django.contrib.sessions',
         'django.contrib.messages',
         'django.contrib.staticfiles',
+        'corsheaders',
         'sortedm2m_filter_horizontal_widget',
         'oidc_provider',
         'rest_framework',
@@ -47,7 +48,7 @@ class Common(Configuration):
         'django.contrib.auth.middleware.AuthenticationMiddleware',
         'django.contrib.messages.middleware.MessageMiddleware',
         'django.middleware.clickjacking.XFrameOptionsMiddleware',
-        'kubeportal.middleware.HideAdminForNonStaffMiddleware'    
+        'kubeportal.middleware.HideAdminForNonStaffMiddleware'
     ]
 
     ROOT_URLCONF = 'kubeportal.urls'
@@ -136,8 +137,10 @@ class Common(Configuration):
     USE_L10N = True
     USE_TZ = True
 
-    CORS_ORIGIN_ALLOW_ALL = True
-
+    CORS_ALLOW_ALL_ORIGINS = False
+    CORS_ALLOW_CREDENTIALS = True
+    CORS_ALLOWED_ORIGINS = []
+   
     ALLOWED_HOSTS = ['*']
 
     AUTH_USER_MODEL = 'kubeportal.User'

--- a/kubeportal/settings.py
+++ b/kubeportal/settings.py
@@ -1,5 +1,7 @@
 import os
+from urllib.parse import urlparse
 from configurations import Configuration, values
+
 
 from kubeportal.secret import get_secret_key
 
@@ -111,7 +113,7 @@ class Common(Configuration):
         'allauth.account.auth_backends.AuthenticationBackend'
     )
 
-    SOCIALACCOUNT_QUERY_EMAIL=True
+    SOCIALACCOUNT_QUERY_EMAIL = True
     SOCIALACCOUNT_PROVIDERS = {}
     AUTH_AD_DOMAIN = values.Value(None, environ_prefix='KUBEPORTAL')
     AUTH_AD_SERVER = values.Value(None, environ_prefix='KUBEPORTAL')
@@ -137,11 +139,13 @@ class Common(Configuration):
     USE_L10N = True
     USE_TZ = True
 
+    ALLOWED_URLS = values.ListValue([], environ_prefix='KUBEPORTAL')
+    ALLOWS_HOSTS = [urlparse(url).netloc for url in ALLOWED_URLS.value]
+    # Please note that '*' is no longer an option:
+    # https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#Credentialed_requests_and_wildcards
     CORS_ALLOW_ALL_ORIGINS = False
     CORS_ALLOW_CREDENTIALS = True
-    CORS_ALLOWED_ORIGINS = []
-   
-    ALLOWED_HOSTS = ['*']
+    CORS_ALLOWED_ORIGINS = ALLOWED_URLS.value
 
     AUTH_USER_MODEL = 'kubeportal.User'
 
@@ -192,8 +196,6 @@ class Development(Common):
 
     DEBUG = True
 
-    REDIRECT_HOSTS = ['localhost', '127.0.0.1']
-
     EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
     EMAIL_HOST = values.Value('localhost', environ_prefix='KUBEPORTAL')
 
@@ -243,8 +245,6 @@ class Production(Common):
 
     STATIC_ROOT = values.Value('', environ_prefix='KUBEPORTAL')
     STATICFILES_DIRS = values.TupleValue('', environ_prefix='KUBEPORTAL')
-
-    REDIRECT_HOSTS = values.TupleValue(None, environ_prefix='KUBEPORTAL')
 
     EMAIL_HOST = values.Value('localhost', environ_prefix='KUBEPORTAL')
 

--- a/kubeportal/tests/test_api.py
+++ b/kubeportal/tests/test_api.py
@@ -1,4 +1,4 @@
-from django.test import override_settings
+from django.test import override_settings, modify_settings
 from rest_framework.test import RequestsClient
 from kubeportal.tests import AdminLoggedOutTestCase, admin_data, admin_clear_password
 from kubeportal.api.views import ClusterViewSet
@@ -9,12 +9,14 @@ from django.contrib.auth import get_user_model
 
 User = get_user_model()
 
+
 class ApiTestCase(AdminLoggedOutTestCase):
     '''
     We take the more complicated way here, and implement the API tests
     with Python requests. This ensures that we are getting as close as possible
     to 'real' API clients, e.g. from JavaScript.
     '''
+
     def setUp(self):
         super().setUp()
         self.client = RequestsClient()
@@ -29,8 +31,8 @@ class ApiTestCase(AdminLoggedOutTestCase):
 
     def patch(self, relative_url, data):
         return self.client.patch('http://testserver' + relative_url,
-                                json=data,
-                                headers={'X-CSRFToken': self.csrftoken})
+                                 json=data,
+                                 headers={'X-CSRFToken': self.csrftoken})
 
     def post(self, relative_url, data={}):
         return self.client.post('http://testserver' + relative_url,
@@ -46,6 +48,7 @@ class ApiAnonymous(ApiTestCase):
     '''
     Tests for API functionality when nobody is logged in.
     '''
+
     def setUp(self):
         super().setUp()
 
@@ -58,17 +61,16 @@ class ApiAnonymous(ApiTestCase):
         self.assertIn('Set-Cookie', response.headers)
         self.assertIn('kubeportal-auth=', response.headers['Set-Cookie'])
         from http.cookies import SimpleCookie
-        cookie = SimpleCookie() 
+        cookie = SimpleCookie()
         cookie.load(response.headers['Set-Cookie'])
-        self.assertEqual(cookie['kubeportal-auth']['path'], '/')  
-        self.assertEqual(cookie['kubeportal-auth']['samesite'], 'Lax,')  
-        self.assertEqual(cookie['kubeportal-auth']['httponly'], True)  
+        self.assertEqual(cookie['kubeportal-auth']['path'], '/')
+        self.assertEqual(cookie['kubeportal-auth']['samesite'], 'Lax,')
+        self.assertEqual(cookie['kubeportal-auth']['httponly'], True)
         data = response.json()
         self.assertEqual(2, len(data))
         self.assertIn('firstname', data)
         self.assertIn('id', data)
         self.assertEqual(data['id'], self.admin.pk)
-
 
     def test_api_wrong_login(self):
         response = self.post(F'/api/{API_VERSION}/login', {'username': admin_data['username'], 'password': 'blabla'})
@@ -81,7 +83,8 @@ class ApiAnonymous(ApiTestCase):
                 self.assertEqual(response.status_code, 401)
 
     def test_webapp_denied(self):
-        app1 = WebApplication(name="app1", link_show=True, link_name="app1", link_url="http://www.heise.de")
+        app1 = WebApplication(name="app1", link_show=True,
+                              link_name="app1", link_url="http://www.heise.de")
         app1.save()
         self.admin_group.can_web_applications.add(app1)
 
@@ -89,7 +92,8 @@ class ApiAnonymous(ApiTestCase):
         self.assertEqual(response.status_code, 401)
 
     def test_user_webapps_denied(self):
-        app1 = WebApplication(name="app1", link_show=True, link_name="app1", link_url="http://www.heise.de")
+        app1 = WebApplication(name="app1", link_show=True,
+                              link_name="app1", link_url="http://www.heise.de")
         app1.save()
         self.admin_group.can_web_applications.add(app1)
 
@@ -110,12 +114,12 @@ class ApiAnonymous(ApiTestCase):
         self.assertEqual(response.status_code, 200)
 
     @override_settings(SOCIALACCOUNT_PROVIDERS={'google': {
-            'APP': {
-                'secret': '123',
-                'client_id': '456'
-            },
-            'SCOPE': ['profile', 'email'],
-    }})    
+        'APP': {
+            'secret': '123',
+            'client_id': '456'
+        },
+        'SCOPE': ['profile', 'email'],
+    }})
     def test_invalid_google_login(self):
         '''
         We have no valid OAuth credentials when running the test suite, but at least
@@ -124,27 +128,26 @@ class ApiAnonymous(ApiTestCase):
         response = self.post(F'/api/{API_VERSION}/login_google', {'access_token': 'foo', 'code': 'bar'})
         self.assertEqual(response.status_code, 400)
 
+
 class ApiLocalUser(ApiTestCase):
     '''
     Tests for API functionality when a local Django user is logged in.
     '''
     user_attr_expected = [
-        'firstname', 
-        'name', 
-        'username', 
-        'primary_email', 
-        'all_emails', 
-        'admin', 
-        'k8s_serviceaccount', 
-        'k8s_namespace', 
-        'k8s_token', 
-    ]        
-
+        'firstname',
+        'name',
+        'username',
+        'primary_email',
+        'all_emails',
+        'admin',
+        'k8s_serviceaccount',
+        'k8s_namespace',
+        'k8s_token',
+    ]
 
     def setUp(self):
         super().setUp()
         self.api_login()
-
 
     def test_cluster(self):
         for stat in ClusterViewSet.stats.keys():
@@ -155,32 +158,32 @@ class ApiLocalUser(ApiTestCase):
                 self.assertIn('value', data.keys())
                 self.assertIsNotNone(data['value'])
 
-    @override_settings(CORS_ALLOWED_ORIGINS=['http://testserver', ],
-                       CORS_ALLOW_CREDENTIALS=True)
+    @override_settings(ALLOWED_URLS=['http://testserver', ])
     def test_cors_single_origin(self):
-        # Only requests with 'Origin' header are CORS-related:
-        # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Origin
-        # https://github.com/adamchainz/django-cors-headers/blob/master/tests/test_middleware.py
         headers = {'Origin': 'http://testserver'}
-        response = self.get(f'/api/{API_VERSION}/cluster/portal_version', headers=headers)
-        self.assertEqual(response.headers['Access-Control-Allow-Origin'], 'http://testserver')
-        self.assertEqual(response.headers['Access-Control-Allow-Credentials'], 'true')
+        relative_urls = [f'/api/{API_VERSION}/login', f'/api/{API_VERSION}/cluster/portal_version']
+        for url in relative_urls:
+            with self.subTest(url=url):        
+                response = self.get(url, headers=headers)
+                self.assertEqual(
+                    response.headers['Access-Control-Allow-Origin'], 'http://testserver')
+                self.assertEqual(
+                    response.headers['Access-Control-Allow-Credentials'], 'true')
 
-    @override_settings(CORS_ALLOWED_ORIGINS=['http://testserver', 'https://example.org:8000'])
-    def test_cors_multiple_origin(self):
+    @override_settings(ALLOWED_URLS=['http://testserver', 'https://example.org:8000'])
+    def test_cors_multiple_allowed(self):
         headers = {'Origin': 'http://testserver'}
         response = self.get(f'/api/{API_VERSION}/cluster/portal_version', headers=headers)
-        self.assertEqual(response.headers['Access-Control-Allow-Origin'], 'http://testserver')
-        headers = {'Origin': 'https://example.org:8000'}
-        response = self.get(f'/api/{API_VERSION}/cluster/portal_version', headers=headers)
-        self.assertEqual(response.headers['Access-Control-Allow-Origin'], 'https://example.org:8000')
+        self.assertEqual(
+            response.headers['Access-Control-Allow-Origin'], 'http://testserver')
 
     def test_cluster_invalid(self):
         response = self.get(F'/api/{API_VERSION}/cluster/foobar')
         self.assertEqual(response.status_code, 404)
 
     def test_webapp_user_not_in_group(self):
-        app1 = WebApplication(name="app1", link_show=True, link_name="app1", link_url="http://www.heise.de")
+        app1 = WebApplication(name="app1", link_show=True,
+                              link_name="app1", link_url="http://www.heise.de")
         app1.save()
 
         response = self.get(F'/api/{API_VERSION}/webapps/{app1.pk}')
@@ -190,18 +193,18 @@ class ApiLocalUser(ApiTestCase):
         response = self.get(F'/api/{API_VERSION}/webapps/777')
         self.assertEqual(response.status_code, 404)
 
-
     def test_webapp_invisible(self):
-        app1 = WebApplication(name="app1", link_show=False, link_name="app1", link_url="http://www.heise.de")
+        app1 = WebApplication(name="app1", link_show=False,
+                              link_name="app1", link_url="http://www.heise.de")
         app1.save()
         self.admin_group.can_web_applications.add(app1)
 
         response = self.get(F'/api/{API_VERSION}/webapps/{app1.pk}')
         self.assertEqual(response.status_code, 403)
 
-
     def test_webapp(self):
-        app1 = WebApplication(name="app1", link_show=True, link_name="app1", link_url="http://www.heise.de")
+        app1 = WebApplication(name="app1", link_show=True,
+                              link_name="app1", link_url="http://www.heise.de")
         app1.save()
         self.admin_group.can_web_applications.add(app1)
 
@@ -213,13 +216,17 @@ class ApiLocalUser(ApiTestCase):
         self.assertEqual(data['link_url'], 'http://www.heise.de')
 
     def test_user_webapps(self):
-        app1 = WebApplication(name="app1", link_show=True, link_name="app1", link_url="http://www.heise.de")
+        app1 = WebApplication(name="app1", link_show=True,
+                              link_name="app1", link_url="http://www.heise.de")
         app1.save()
-        app2 = WebApplication(name="app2", link_show=True, link_name="app2", link_url="http://www.spiegel.de")
+        app2 = WebApplication(name="app2", link_show=True,
+                              link_name="app2", link_url="http://www.spiegel.de")
         app2.save()
-        app3 = WebApplication(name="app3", link_show=False, link_name="app3", link_url="http://www.crappydemo.de")
+        app3 = WebApplication(name="app3", link_show=False,
+                              link_name="app3", link_url="http://www.crappydemo.de")
         app3.save()
-        app4 = WebApplication(name="app4", link_show=True, link_name="app4", link_url="http://www.unrelatedapp.de")
+        app4 = WebApplication(name="app4", link_show=True,
+                              link_name="app4", link_url="http://www.unrelatedapp.de")
         app4.save()
         self.admin_group.can_web_applications.add(app1)
         self.admin_group.can_web_applications.add(app2)
@@ -228,11 +235,14 @@ class ApiLocalUser(ApiTestCase):
         response = self.get(F'/api/{API_VERSION}/users/{self.admin.pk}/webapps')
         self.assertEqual(response.status_code, 200)
         data = response.json()
-        self.assertIn({'link_name': 'app1', 'link_url': 'http://www.heise.de'}, data)
-        self.assertIn({'link_name': 'app2', 'link_url': 'http://www.spiegel.de'}, data)
-        self.assertNotIn({'link_name': 'app3', 'link_url': 'http://www.crappydemo.de'}, data)
-        self.assertNotIn({'link_name': 'app4', 'link_url': 'http://www.unrelatedapp.de'}, data)
-
+        self.assertIn(
+            {'link_name': 'app1', 'link_url': 'http://www.heise.de'}, data)
+        self.assertIn(
+            {'link_name': 'app2', 'link_url': 'http://www.spiegel.de'}, data)
+        self.assertNotIn(
+            {'link_name': 'app3', 'link_url': 'http://www.crappydemo.de'}, data)
+        self.assertNotIn(
+            {'link_name': 'app4', 'link_url': 'http://www.unrelatedapp.de'}, data)
 
     def test_user_webapps_invalid_id(self):
         response = self.get(F'/api/{API_VERSION}/users/777/webapps')
@@ -252,7 +262,8 @@ class ApiLocalUser(ApiTestCase):
         data = response.json()
         for entry in data:
             self.assertIn('name', entry.keys())
-        self.assertEqual(4, len(data))  #  Auto group "all users", Test case group "Admins", plus 2 extra
+        # Auto group "all users", Test case group "Admins", plus 2 extra
+        self.assertEqual(4, len(data))
 
     def test_group(self):
         response = self.get(F'/api/{API_VERSION}/groups/{self.admin_group.pk}')
@@ -265,7 +276,6 @@ class ApiLocalUser(ApiTestCase):
         response = self.get(F'/api/{API_VERSION}/groups/777')
         self.assertEqual(response.status_code, 404)
 
-
     def test_group_non_member(self):
         group1 = PortalGroup(name="group1")
         group1.save()
@@ -276,7 +286,6 @@ class ApiLocalUser(ApiTestCase):
     def test_group_invalid_id(self):
         response = self.get(F'/api/{API_VERSION}/users/777/groups')
         self.assertEqual(response.status_code, 403)
-
 
     def test_user(self):
 
@@ -339,6 +348,7 @@ class ApiLogout(ApiTestCase):
     '''
     Tests for API logout functionality when a local Django user is logged in.
     '''
+
     def setUp(self):
         super().setUp()
         self.api_login()
@@ -346,4 +356,3 @@ class ApiLogout(ApiTestCase):
     def test_logout(self):
         response = self.post(F'/api/{API_VERSION}/logout')
         self.assertEqual(response.status_code, 200)
-

--- a/requirements-prod.txt
+++ b/requirements-prod.txt
@@ -9,7 +9,7 @@ dj-database-url
 django-fsm
 djangorestframework
 python-jose
-django-cors-middleware
+django-cors-headers
 django-sortedm2m-filter-horizontal-widget
 django-multi-email-field
 dj-rest-auth[with_social]

--- a/requirements-prod.txt
+++ b/requirements-prod.txt
@@ -9,7 +9,6 @@ dj-database-url
 django-fsm
 djangorestframework
 python-jose
-django-cors-headers
 django-sortedm2m-filter-horizontal-widget
 django-multi-email-field
 dj-rest-auth[with_social]


### PR DESCRIPTION
An attempt to fix the CORS issues. You need to set KUBEPORTAL_ALLOWED_URLS with the list of URLs this server is reachable under.  It would be nice to have a test against the latest kubeportal-Frontensegeln Code.