### PR TITLE
API v1.3.0

### DIFF
--- a/kubeportal/settings.py
+++ b/kubeportal/settings.py
@@ -6,7 +6,7 @@ from kubeportal.secret import get_secret_key
 
 class Common(Configuration):
     VERSION = '0.4.0'
-    API_VERSION = 'v1.2.0'
+    API_VERSION = 'v1.3.0'
 
     SITE_ID = 1
 
@@ -72,7 +72,7 @@ class Common(Configuration):
             'DEFAULT_VERSIONING_CLASS':
             'rest_framework.versioning.URLPathVersioning',
             'DEFAULT_AUTHENTICATION_CLASSES': [
-                'dj_rest_auth.jwt_auth.JWTCookieAuthentication',
+                'rest_framework_simplejwt.authentication.JWTAuthentication',
                 ],
             'DEFAULT_PERMISSION_CLASSES': [
                 'rest_framework.permissions.IsAuthenticated',
@@ -84,7 +84,6 @@ class Common(Configuration):
             }
 
     REST_USE_JWT = True
-    JWT_AUTH_COOKIE = 'kubeportal-auth'
 
 
     WSGI_APPLICATION = 'kubeportal.wsgi.application'


### PR DESCRIPTION
API v.1.3.0 demands JWT token auth as part of the request header. This is realized here, including according tests.

If you want to try it out:

- Perform a POST to `/api/v1.3.0/login`. When successful, you get a JWT and a CSRF token in the response body as result.
- The CRSF token should be automatically part of every subsequent request with the following header:
```
X-CSRFToken: <csrftoken>
```
- The JWT should be automatically part of every subsequent request with the following header:
```
Authorization: Bearer <jwt>
```
Token lifetime and refresh is currently not tackled here.