### PR TITLE
authorize options by default

### DIFF
--- a/kubeportal/api/views.py
+++ b/kubeportal/api/views.py
@@ -157,7 +157,7 @@ class ClusterViewSet(mixins.RetrieveModelMixin, viewsets.GenericViewSet):
     def retrieve(self, request, *args, **kwargs):
         key = kwargs['pk']
         if key in self.stats.keys():
-            return Response({'value': self.stats[key]()})
+            return Response({key: self.stats[key]()})
         else:
             raise NotFound
 
@@ -173,6 +173,5 @@ class BootstrapView(APIView):
             'csrf_token': csrf.get_token(request),
             'portal_version': 'v' + get_kubeportal_version(),
             'default_api_version': settings.API_VERSION
-
         }
         return Response(data)

--- a/kubeportal/middleware.py
+++ b/kubeportal/middleware.py
@@ -2,6 +2,7 @@ from django.http import Http404
 from django.shortcuts import redirect
 from django.urls import reverse
 from kubeportal import settings
+from rest_framework.permissions import IsAuthenticated
 import logging
 
 logger = logging.getLogger('KubePortal')
@@ -94,3 +95,10 @@ class CorsMiddleware:
                                                    "Access-Control-Request-Method, Access-Control-Request-Headers," \
                                                    "Authorization, X-CSRFToken"
         return response
+
+
+class AllowOptionsAuthentication(IsAuthenticated):
+    def has_permission(self, request, view):
+        if request.method == 'OPTIONS':
+            return True
+        return request.user and request.user.is_authenticated

--- a/kubeportal/settings.py
+++ b/kubeportal/settings.py
@@ -75,7 +75,7 @@ class Common(Configuration):
                 'rest_framework_simplejwt.authentication.JWTAuthentication',
                 ],
             'DEFAULT_PERMISSION_CLASSES': [
-                'rest_framework.permissions.IsAuthenticated',
+                'kubeportal.middleware.AllowOptionsAuthentication',
                 ],
             'DEFAULT_VERSION': API_VERSION,
             'ALLOWED_VERSIONS': [

--- a/kubeportal/tests/test_api.py
+++ b/kubeportal/tests/test_api.py
@@ -202,8 +202,8 @@ class ApiLocalUser(ApiTestCase):
                 response = self.get(f'/api/{API_VERSION}/cluster/{stat}/')
                 self.assertEqual(200, response.status_code)
                 data = response.json()
-                self.assertIn('value', data.keys())
-                self.assertIsNotNone(data['value'])
+                self.assertIn(stat, data.keys())
+                self.assertIsNotNone(data[stat])
 
     @override_settings(ALLOWED_URLS=['http://testserver', ])
     def test_cors_single_origin(self):


### PR DESCRIPTION
options preflights don't include the configured headers. this could be a solution.
