### PR TITLE
API Streamlining

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -11,7 +11,10 @@ jobs:
     strategy:
       fail-fast: False
       matrix:
-        k8sversion: ['v1.14.10', 'v1.15.12', 'v1.16.15', 'v1.17.17', 'v1.18.17', 'v1.19.9', 'v1.20.2']
+        # v1.14 - v1.16 need a different handling in the minikube 
+        # test handling, specifically regarding the name of the API
+        # server pod.
+        k8sversion: ['v1.17.17', 'v1.18.16', 'v1.19.8', 'v1.20.2']
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python 3.8

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -9,6 +9,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: False
       matrix:
         k8sversion: ['v1.14.10', 'v1.15.12', 'v1.16.15', 'v1.17.17', 'v1.18.17', 'v1.19.9', 'v1.20.2']
     steps:

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -27,18 +27,18 @@ jobs:
       - name: Setup Minikube
         uses: manusa/actions-setup-minikube@v2.3.0
         with:
-          minikube version: 'v1.16.0'
+          minikube version: 'v1.18.1'
           kubernetes version: ${{ matrix.k8sversion }}
           github token: ${{ secrets.GITHUB_TOKEN }}
           driver: docker
       - name: run Unittest without coverage
-        if: ${{ matrix.k8sversion != 'v1.18.15' }}
+        if: ${{ matrix.k8sversion != 'v1.18.17' }}
         run: pytest
       - name: run Unittest, including coverage analysis
-        if: ${{ matrix.k8sversion == 'v1.18.15' }}
+        if: ${{ matrix.k8sversion == 'v1.18.17' }}
         run: pytest --cov=./ --cov-report=xml
       - name: Upload coverage to Codecov
-        if: ${{ matrix.k8sversion == 'v1.18.15' }}
+        if: ${{ matrix.k8sversion == 'v1.18.17' }}
         uses: codecov/codecov-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           pip install pytest-cov
       - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.3.0
+        uses: manusa/actions-setup-minikube@v2.3.1
         with:
           minikube version: 'v1.18.1'
           kubernetes version: ${{ matrix.k8sversion }}

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -7,10 +7,10 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        k8sversion: ['v1.17.17', 'v1.18.15', 'v1.19.7', 'v1.20.2']
+        k8sversion: ['v1.15', 'v1.16', 'v1.17', 'v1.18', 'v1.19', 'v1.20']
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python 3.8

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        k8sversion: ['v1.15', 'v1.16', 'v1.17', 'v1.18', 'v1.19', 'v1.20']
+        k8sversion: ['v1.14.10', 'v1.15.12', 'v1.16.15', 'v1.17.17', 'v1.18.17', 'v1.19.9', 'v1.20.2']
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python 3.8

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -3,8 +3,30 @@
   <component name="ChangeListManager">
     <list default="true" id="9f525e2b-06cc-4b3e-bd05-de80d9c4b9c7" name="Default Changelist" comment="">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/kubeportal/api/views/__init__.py" beforeDir="false" afterPath="$PROJECT_DIR$/kubeportal/api/views/__init__.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/kubeportal/api/views/bootstrapinfo.py" beforeDir="false" afterPath="$PROJECT_DIR$/kubeportal/api/views/bootstrapinfo.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/kubeportal/api/views/deployments.py" beforeDir="false" afterPath="$PROJECT_DIR$/kubeportal/api/views/deployments.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/kubeportal/api/views/info.py" beforeDir="false" afterPath="$PROJECT_DIR$/kubeportal/api/views/info.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/kubeportal/api/views/ingresses.py" beforeDir="false" afterPath="$PROJECT_DIR$/kubeportal/api/views/ingresses.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/kubeportal/api/views/ingresshosts.py" beforeDir="false" afterPath="$PROJECT_DIR$/kubeportal/api/views/ingresshosts.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/kubeportal/api/views/login.py" beforeDir="false" afterPath="$PROJECT_DIR$/kubeportal/api/views/login.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/kubeportal/api/views/namespaces.py" beforeDir="false" afterPath="$PROJECT_DIR$/kubeportal/api/views/namespaces.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/kubeportal/api/views/news.py" beforeDir="false" afterPath="$PROJECT_DIR$/kubeportal/api/views/news.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/kubeportal/api/views/pods.py" beforeDir="false" afterPath="$PROJECT_DIR$/kubeportal/api/views/pods.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/kubeportal/api/views/serviceaccounts.py" beforeDir="false" afterPath="$PROJECT_DIR$/kubeportal/api/views/serviceaccounts.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/kubeportal/api/views/services.py" beforeDir="false" afterPath="$PROJECT_DIR$/kubeportal/api/views/services.py" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/kubeportal/api/views/users.py" beforeDir="false" afterPath="$PROJECT_DIR$/kubeportal/api/views/users.py" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/kubeportal/models/__init__.py" beforeDir="false" afterPath="$PROJECT_DIR$/kubeportal/models/__init__.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/kubeportal/k8s/kubernetes_api.py" beforeDir="false" afterPath="$PROJECT_DIR$/kubeportal/k8s/kubernetes_api.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/kubeportal/tests/fixtures/ingress1.yml" beforeDir="false" afterPath="$PROJECT_DIR$/kubeportal/tests/fixtures/ingress1.yml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/kubeportal/tests/test_api.py" beforeDir="false" afterPath="$PROJECT_DIR$/kubeportal/tests/test_api.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/kubeportal/tests/test_api_deployments.py" beforeDir="false" afterPath="$PROJECT_DIR$/kubeportal/tests/test_api_deployments.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/kubeportal/tests/test_api_ingresses.py" beforeDir="false" afterPath="$PROJECT_DIR$/kubeportal/tests/test_api_ingresses.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/kubeportal/tests/test_api_news.py" beforeDir="false" afterPath="$PROJECT_DIR$/kubeportal/tests/test_api_news.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/kubeportal/tests/test_api_pods.py" beforeDir="false" afterPath="$PROJECT_DIR$/kubeportal/tests/test_api_pods.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/kubeportal/tests/test_api_security.py" beforeDir="false" afterPath="$PROJECT_DIR$/kubeportal/tests/test_api_security.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/kubeportal/tests/test_api_services.py" beforeDir="false" afterPath="$PROJECT_DIR$/kubeportal/tests/test_api_services.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/kubeportal/tests/test_api_users.py" beforeDir="false" afterPath="$PROJECT_DIR$/kubeportal/tests/test_api_users.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/kubeportal/urls.py" beforeDir="false" afterPath="$PROJECT_DIR$/kubeportal/urls.py" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -179,6 +201,7 @@
         </entry>
       </map>
     </option>
+    <option name="oldMeFiltersMigrated" value="true" />
   </component>
   <component name="VcsManagerConfiguration">
     <MESSAGE value="PEP-8, fix tests" />

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -3,29 +3,15 @@
   <component name="ChangeListManager">
     <list default="true" id="9f525e2b-06cc-4b3e-bd05-de80d9c4b9c7" name="Default Changelist" comment="">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/kubeportal/api/views/__init__.py" beforeDir="false" afterPath="$PROJECT_DIR$/kubeportal/api/views/__init__.py" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/kubeportal/api/views/bootstrapinfo.py" beforeDir="false" afterPath="$PROJECT_DIR$/kubeportal/api/views/bootstrapinfo.py" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/kubeportal/api/views/deployments.py" beforeDir="false" afterPath="$PROJECT_DIR$/kubeportal/api/views/deployments.py" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/kubeportal/api/views/info.py" beforeDir="false" afterPath="$PROJECT_DIR$/kubeportal/api/views/info.py" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/kubeportal/api/views/ingresses.py" beforeDir="false" afterPath="$PROJECT_DIR$/kubeportal/api/views/ingresses.py" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/kubeportal/api/views/ingresshosts.py" beforeDir="false" afterPath="$PROJECT_DIR$/kubeportal/api/views/ingresshosts.py" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/kubeportal/api/views/login.py" beforeDir="false" afterPath="$PROJECT_DIR$/kubeportal/api/views/login.py" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/kubeportal/api/views/namespaces.py" beforeDir="false" afterPath="$PROJECT_DIR$/kubeportal/api/views/namespaces.py" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/kubeportal/api/views/news.py" beforeDir="false" afterPath="$PROJECT_DIR$/kubeportal/api/views/news.py" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/kubeportal/api/views/pods.py" beforeDir="false" afterPath="$PROJECT_DIR$/kubeportal/api/views/pods.py" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/kubeportal/api/views/serviceaccounts.py" beforeDir="false" afterPath="$PROJECT_DIR$/kubeportal/api/views/serviceaccounts.py" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/kubeportal/api/views/services.py" beforeDir="false" afterPath="$PROJECT_DIR$/kubeportal/api/views/services.py" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/kubeportal/api/views/users.py" beforeDir="false" afterPath="$PROJECT_DIR$/kubeportal/api/views/users.py" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/kubeportal/k8s/kubernetes_api.py" beforeDir="false" afterPath="$PROJECT_DIR$/kubeportal/k8s/kubernetes_api.py" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/kubeportal/tests/fixtures/ingress1.yml" beforeDir="false" afterPath="$PROJECT_DIR$/kubeportal/tests/fixtures/ingress1.yml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/kubeportal/tests/test_api.py" beforeDir="false" afterPath="$PROJECT_DIR$/kubeportal/tests/test_api.py" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/kubeportal/tests/test_api_deployments.py" beforeDir="false" afterPath="$PROJECT_DIR$/kubeportal/tests/test_api_deployments.py" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/kubeportal/tests/test_api_ingresses.py" beforeDir="false" afterPath="$PROJECT_DIR$/kubeportal/tests/test_api_ingresses.py" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/kubeportal/tests/test_api_news.py" beforeDir="false" afterPath="$PROJECT_DIR$/kubeportal/tests/test_api_news.py" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/kubeportal/tests/test_api_pods.py" beforeDir="false" afterPath="$PROJECT_DIR$/kubeportal/tests/test_api_pods.py" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/kubeportal/tests/test_api_security.py" beforeDir="false" afterPath="$PROJECT_DIR$/kubeportal/tests/test_api_security.py" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/kubeportal/tests/test_api_services.py" beforeDir="false" afterPath="$PROJECT_DIR$/kubeportal/tests/test_api_services.py" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/kubeportal/tests/test_api_users.py" beforeDir="false" afterPath="$PROJECT_DIR$/kubeportal/tests/test_api_users.py" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/kubeportal/urls.py" beforeDir="false" afterPath="$PROJECT_DIR$/kubeportal/urls.py" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
@@ -52,30 +38,30 @@
     <property name="last_opened_file_path" value="$PROJECT_DIR$/Makefile" />
     <property name="settings.editor.selected.configurable" value="preferences.keymap" />
   </component>
-  <component name="RunManager" selected="Python tests.pytest in test_front_unappr.py">
+  <component name="RunManager" selected="Python tests.pytest for kubeportal.tests.test_api_services.test_user_services_list">
     <configuration name="Prepare tests" type="MAKEFILE_TARGET_RUN_CONFIGURATION" factoryName="Makefile">
       <makefile filename="$PROJECT_DIR$/Makefile" target="minikube-start" workingDirectory="" arguments="">
         <envs />
       </makefile>
       <method v="2" />
     </configuration>
-    <configuration name="pytest for tests.test_models.test_user_k8s_namespaces" type="tests" factoryName="py.test" temporary="true" nameIsGenerated="true">
+    <configuration name="pytest for kubeportal.tests.test_api_ingresses.test_user_ingresses_list" type="tests" factoryName="py.test" temporary="true" nameIsGenerated="true">
       <module name="kubeportal" />
       <option name="INTERPRETER_OPTIONS" value="" />
       <option name="PARENT_ENVS" value="true" />
       <option name="SDK_HOME" value="" />
-      <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/kubeportal" />
+      <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/kubeportal/tests" />
       <option name="IS_MODULE_SDK" value="true" />
       <option name="ADD_CONTENT_ROOTS" value="true" />
       <option name="ADD_SOURCE_ROOTS" value="true" />
       <option name="_new_keywords" value="&quot;&quot;" />
       <option name="_new_parameters" value="&quot;&quot;" />
       <option name="_new_additionalArguments" value="&quot;&quot;" />
-      <option name="_new_target" value="&quot;tests.test_models.test_user_k8s_namespaces&quot;" />
+      <option name="_new_target" value="&quot;kubeportal.tests.test_api_ingresses.test_user_ingresses_list&quot;" />
       <option name="_new_targetType" value="&quot;PYTHON&quot;" />
       <method v="2" />
     </configuration>
-    <configuration name="pytest in test_api.py" type="tests" factoryName="py.test" temporary="true" nameIsGenerated="true">
+    <configuration name="pytest for kubeportal.tests.test_api_pods.test_namespace_pods_list" type="tests" factoryName="py.test" temporary="true" nameIsGenerated="true">
       <module name="kubeportal" />
       <option name="INTERPRETER_OPTIONS" value="" />
       <option name="PARENT_ENVS" value="true" />
@@ -87,11 +73,11 @@
       <option name="_new_keywords" value="&quot;&quot;" />
       <option name="_new_parameters" value="&quot;&quot;" />
       <option name="_new_additionalArguments" value="&quot;&quot;" />
-      <option name="_new_target" value="&quot;$PROJECT_DIR$/kubeportal/tests/test_api.py&quot;" />
-      <option name="_new_targetType" value="&quot;PATH&quot;" />
+      <option name="_new_target" value="&quot;kubeportal.tests.test_api_pods.test_namespace_pods_list&quot;" />
+      <option name="_new_targetType" value="&quot;PYTHON&quot;" />
       <method v="2" />
     </configuration>
-    <configuration name="pytest in test_front_unappr.py" type="tests" factoryName="py.test" temporary="true" nameIsGenerated="true">
+    <configuration name="pytest for kubeportal.tests.test_api_services.test_user_services_list" type="tests" factoryName="py.test" temporary="true" nameIsGenerated="true">
       <module name="kubeportal" />
       <option name="INTERPRETER_OPTIONS" value="" />
       <option name="PARENT_ENVS" value="true" />
@@ -103,27 +89,11 @@
       <option name="_new_keywords" value="&quot;&quot;" />
       <option name="_new_parameters" value="&quot;&quot;" />
       <option name="_new_additionalArguments" value="&quot;&quot;" />
-      <option name="_new_target" value="&quot;$PROJECT_DIR$/kubeportal/tests/test_front_unappr.py&quot;" />
-      <option name="_new_targetType" value="&quot;PATH&quot;" />
+      <option name="_new_target" value="&quot;kubeportal.tests.test_api_services.test_user_services_list&quot;" />
+      <option name="_new_targetType" value="&quot;PYTHON&quot;" />
       <method v="2" />
     </configuration>
-    <configuration name="pytest in test_models.py" type="tests" factoryName="py.test" temporary="true" nameIsGenerated="true">
-      <module name="kubeportal" />
-      <option name="INTERPRETER_OPTIONS" value="" />
-      <option name="PARENT_ENVS" value="true" />
-      <option name="SDK_HOME" value="" />
-      <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/kubeportal" />
-      <option name="IS_MODULE_SDK" value="true" />
-      <option name="ADD_CONTENT_ROOTS" value="true" />
-      <option name="ADD_SOURCE_ROOTS" value="true" />
-      <option name="_new_keywords" value="&quot;&quot;" />
-      <option name="_new_parameters" value="&quot;&quot;" />
-      <option name="_new_additionalArguments" value="&quot;&quot;" />
-      <option name="_new_target" value="&quot;$PROJECT_DIR$/kubeportal/tests/test_models.py&quot;" />
-      <option name="_new_targetType" value="&quot;PATH&quot;" />
-      <method v="2" />
-    </configuration>
-    <configuration name="pytest in test_subauth.py" type="tests" factoryName="py.test" temporary="true" nameIsGenerated="true">
+    <configuration name="pytest in test_api_ingresses.py" type="tests" factoryName="py.test" temporary="true" nameIsGenerated="true">
       <module name="kubeportal" />
       <option name="INTERPRETER_OPTIONS" value="" />
       <option name="PARENT_ENVS" value="true" />
@@ -135,26 +105,42 @@
       <option name="_new_keywords" value="&quot;&quot;" />
       <option name="_new_parameters" value="&quot;&quot;" />
       <option name="_new_additionalArguments" value="&quot;&quot;" />
-      <option name="_new_target" value="&quot;$PROJECT_DIR$/kubeportal/tests/test_subauth.py&quot;" />
+      <option name="_new_target" value="&quot;$PROJECT_DIR$/kubeportal/tests/test_api_ingresses.py&quot;" />
+      <option name="_new_targetType" value="&quot;PATH&quot;" />
+      <method v="2" />
+    </configuration>
+    <configuration name="pytest in test_api_services.py" type="tests" factoryName="py.test" temporary="true" nameIsGenerated="true">
+      <module name="kubeportal" />
+      <option name="INTERPRETER_OPTIONS" value="" />
+      <option name="PARENT_ENVS" value="true" />
+      <option name="SDK_HOME" value="" />
+      <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/kubeportal/tests" />
+      <option name="IS_MODULE_SDK" value="true" />
+      <option name="ADD_CONTENT_ROOTS" value="true" />
+      <option name="ADD_SOURCE_ROOTS" value="true" />
+      <option name="_new_keywords" value="&quot;&quot;" />
+      <option name="_new_parameters" value="&quot;&quot;" />
+      <option name="_new_additionalArguments" value="&quot;&quot;" />
+      <option name="_new_target" value="&quot;$PROJECT_DIR$/kubeportal/tests/test_api_services.py&quot;" />
       <option name="_new_targetType" value="&quot;PATH&quot;" />
       <method v="2" />
     </configuration>
     <list>
       <item itemvalue="Makefile.Prepare tests" />
       <item itemvalue="Python tests.pytest in tests" />
-      <item itemvalue="Python tests.pytest in test_api.py" />
-      <item itemvalue="Python tests.pytest in test_subauth.py" />
-      <item itemvalue="Python tests.pytest in test_models.py" />
-      <item itemvalue="Python tests.pytest for tests.test_models.test_user_k8s_namespaces" />
-      <item itemvalue="Python tests.pytest in test_front_unappr.py" />
+      <item itemvalue="Python tests.pytest for kubeportal.tests.test_api_pods.test_namespace_pods_list" />
+      <item itemvalue="Python tests.pytest in test_api_ingresses.py" />
+      <item itemvalue="Python tests.pytest for kubeportal.tests.test_api_ingresses.test_user_ingresses_list" />
+      <item itemvalue="Python tests.pytest in test_api_services.py" />
+      <item itemvalue="Python tests.pytest for kubeportal.tests.test_api_services.test_user_services_list" />
     </list>
     <recent_temporary>
       <list>
-        <item itemvalue="Python tests.pytest in test_front_unappr.py" />
-        <item itemvalue="Python tests.pytest for tests.test_models.test_user_k8s_namespaces" />
-        <item itemvalue="Python tests.pytest in test_models.py" />
-        <item itemvalue="Python tests.pytest in test_subauth.py" />
-        <item itemvalue="Python tests.pytest in test_api.py" />
+        <item itemvalue="Python tests.pytest for kubeportal.tests.test_api_services.test_user_services_list" />
+        <item itemvalue="Python tests.pytest in test_api_services.py" />
+        <item itemvalue="Python tests.pytest for kubeportal.tests.test_api_ingresses.test_user_ingresses_list" />
+        <item itemvalue="Python tests.pytest in test_api_ingresses.py" />
+        <item itemvalue="Python tests.pytest for kubeportal.tests.test_api_pods.test_namespace_pods_list" />
       </list>
     </recent_temporary>
   </component>
@@ -188,7 +174,35 @@
       <option name="project" value="LOCAL" />
       <updated>1614605045597</updated>
     </task>
-    <option name="localTasksCounter" value="4" />
+    <task id="LOCAL-00004" summary="Fix test suite, huge consistency fix">
+      <created>1615891579447</created>
+      <option name="number" value="00004" />
+      <option name="presentableId" value="LOCAL-00004" />
+      <option name="project" value="LOCAL" />
+      <updated>1615891579447</updated>
+    </task>
+    <task id="LOCAL-00005" summary="Fix methods for ingress creation">
+      <created>1615892410404</created>
+      <option name="number" value="00005" />
+      <option name="presentableId" value="LOCAL-00005" />
+      <option name="project" value="LOCAL" />
+      <updated>1615892410404</updated>
+    </task>
+    <task id="LOCAL-00006" summary="Unify naming in API">
+      <created>1615892432665</created>
+      <option name="number" value="00006" />
+      <option name="presentableId" value="LOCAL-00006" />
+      <option name="project" value="LOCAL" />
+      <updated>1615892432665</updated>
+    </task>
+    <task id="LOCAL-00007" summary="Fix test case">
+      <created>1615892607330</created>
+      <option name="number" value="00007" />
+      <option name="presentableId" value="LOCAL-00007" />
+      <option name="project" value="LOCAL" />
+      <updated>1615892607330</updated>
+    </task>
+    <option name="localTasksCounter" value="8" />
     <servers />
   </component>
   <component name="Vcs.Log.Tabs.Properties">
@@ -207,7 +221,11 @@
     <MESSAGE value="PEP-8, fix tests" />
     <MESSAGE value="Hyperlinks for webapps" />
     <MESSAGE value="More API hyperlinks, add service accounts and namespaces as resources" />
-    <option name="LAST_COMMIT_MESSAGE" value="More API hyperlinks, add service accounts and namespaces as resources" />
+    <MESSAGE value="Fix test suite, huge consistency fix" />
+    <MESSAGE value="Fix methods for ingress creation" />
+    <MESSAGE value="Unify naming in API" />
+    <MESSAGE value="Fix test case" />
+    <option name="LAST_COMMIT_MESSAGE" value="Fix test case" />
   </component>
   <component name="XDebuggerManager">
     <breakpoint-manager>

--- a/Makefile
+++ b/Makefile
@@ -80,5 +80,6 @@ minikube-check:
 	@test -f /usr/local/bin/minikube \
 	|| test -f /usr/bin/minikube \
 	|| test -f /bin/minikube \
+        || test -f /opt/homebrew/bin/minikube \
 	|| (echo ERROR: Minikube installation is missing on your machine. && exit 1)
 

--- a/kubeportal/api/views/__init__.py
+++ b/kubeportal/api/views/__init__.py
@@ -5,13 +5,12 @@ General design principles:
 
 - API calls always return a JSON object resp. dictionary.
   See https://softwareengineering.stackexchange.com/questions/286293/whats-the-best-way-to-return-an-array-as-a-response-in-a-restful-api
+  This means especially that list-only results are still wrapped in a single
+  key dictionary (e.g. "/infos/")
 - Fields with URL values are named "*_url", since the OpenAPI
   Swagger doc generation cannot map serializer URLField's into
-  proper example values. This gices the developer a hint about the
+  proper example values. This gives the developer a hint about the
   data type.
-- We follow the HATEOAS principle of storing all resource links
-  nested under a "links" key. This is also a proper way for architecting
-  the serializers.
 - Data structures are always described as DRF serializers, even when
   they are not really used in their original sense. This again enables
   the correct work of drf-spectacular for the API doc generation.

--- a/kubeportal/api/views/__init__.py
+++ b/kubeportal/api/views/__init__.py
@@ -1,4 +1,21 @@
-from django.shortcuts import get_object_or_404
+"""
+The Kubeportal REST API.
+
+General design principles:
+
+- API calls always return a JSON object resp. dictionary.
+  See https://softwareengineering.stackexchange.com/questions/286293/whats-the-best-way-to-return-an-array-as-a-response-in-a-restful-api
+- Fields with URL values are named "*_url", since the OpenAPI
+  Swagger doc generation cannot map serializer URLField's into
+  proper example values. This gices the developer a hint about the
+  data type.
+- We follow the HATEOAS principle of storing all resource links
+  nested under a "links" key. This is also a proper way for architecting
+  the serializers.
+- Data structures are always described as DRF serializers, even when
+  they are not really used in their original sense. This again enables
+  the correct work of drf-spectacular for the API doc generation.
+"""
 
 from .bootstrapinfo import *
 from .info import *

--- a/kubeportal/api/views/bootstrapinfo.py
+++ b/kubeportal/api/views/bootstrapinfo.py
@@ -1,24 +1,17 @@
-from drf_spectacular.utils import extend_schema, extend_schema_field
-from drf_spectacular.types import OpenApiTypes
-from rest_framework import generics, serializers
+from django.middleware import csrf
 from drf_spectacular.utils import extend_schema
+from rest_framework import generics, serializers
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from rest_framework.reverse import reverse
-from django.middleware import csrf
-from django.conf import settings
-
-from kubeportal.api.views.tools import get_kubeportal_version
 
 
-class BootstrapLinksSerializer(serializers.Serializer):
+class BootstrapInfoSerializer(serializers.Serializer):
+    csrf_token = serializers.CharField()
     login_url = serializers.URLField()
     logout_url = serializers.URLField()
     login_google_url = serializers.URLField()
 
-class BootstrapInfoSerializer(serializers.Serializer):
-    csrf_token = serializers.CharField()
-    links = BootstrapLinksSerializer()
 
 class BootstrapInfoView(generics.RetrieveAPIView):
     permission_classes = [AllowAny]  # Override default JWT auth
@@ -30,12 +23,8 @@ class BootstrapInfoView(generics.RetrieveAPIView):
     def get(self, request, version):
         instance = BootstrapInfoSerializer({
             "csrf_token": csrf.get_token(request),
-            "links": {
-                "login_url": reverse(viewname='rest_login', request=request),
-                "logout_url": reverse(viewname='rest_logout', request=request),
-                "login_google_url": reverse(viewname='api_google_login', request=request)
-            }
+            "login_url": reverse(viewname='rest_login', request=request),
+            "logout_url": reverse(viewname='rest_logout', request=request),
+            "login_google_url": reverse(viewname='api_google_login', request=request)
         })
         return Response(instance.data)
-
-

--- a/kubeportal/api/views/deployments.py
+++ b/kubeportal/api/views/deployments.py
@@ -3,6 +3,9 @@ from rest_framework import serializers, generics
 from rest_framework.exceptions import NotFound
 from rest_framework.response import Response
 from rest_framework.reverse import reverse
+from drf_spectacular.utils import extend_schema_serializer, OpenApiExample
+
+from .pods import ContainerSerializer
 
 from kubeportal.k8s import kubernetes_api as api
 
@@ -11,29 +14,44 @@ logger = logging.getLogger('KubePortal')
 
 
 
+class LabelSerializer(serializers.Serializer):
+    """
+    The API serializer for a label definition.
+    """
+    key = serializers.CharField()
+    value = serializers.CharField()
+
+
+class PodTemplateSerializer(serializers.Serializer):
+    """
+    The API serializer for a pod template.
+    """
+    name = serializers.CharField()
+    labels = serializers.ListField(child=LabelSerializer())
+    containers = serializers.ListField(child=ContainerSerializer())
+
+class DeploymentLinksSerializer(serializers.Serializer):
+    """
+    The API serializer for the resources a deployment links to.
+    """
+    pod_urls = serializers.ListField(read_only=True, child=serializers.URLField())
+    namespace_url = serializers.URLField()
+
+
 class DeploymentSerializer(serializers.Serializer):
+    """
+    The API serializer for a single deployment.
+    """
     name = serializers.CharField()
     uid = serializers.CharField(read_only=True)
     creation_timestamp = serializers.DateTimeField(read_only=True)
     replicas = serializers.IntegerField()
-    pods = serializers.ListField(child=serializers.URLField())
+    match_labels = serializers.ListField(write_only=True, child=LabelSerializer())
+    pod_template = PodTemplateSerializer(write_only=True)
+    links = DeploymentLinksSerializer(read_only=True)
 
 
-    @classmethod
-    def to_json(cls, deployment, request):
-        """
-        Get our stripped JSON representation of deployment details.
-        """
-        pod_list = api.get_deployment_pods(deployment)
-        stripped_depl = {'name': deployment.metadata.name,
-                         'uid': deployment.metadata.uid,
-                         'creation_timestamp': deployment.metadata.creation_timestamp,
-                         'replicas': deployment.spec.replicas,
-                         'pods': [reverse(viewname='pod', kwargs={'uid': pod.metadata.uid}, request=request) for pod in pod_list]}
-        return stripped_depl                         
-
-
-class DeploymentView(generics.RetrieveAPIView):
+class DeploymentRetrievalView(generics.RetrieveAPIView):
     serializer_class = DeploymentSerializer
 
     @extend_schema(
@@ -41,38 +59,37 @@ class DeploymentView(generics.RetrieveAPIView):
     )
     def get(self, request, version, uid):
         deployment = api.get_deployment(uid)
-        if request.user.has_namespace(deployment.metadata.namespace):
-            return Response(DeploymentSerializer.to_json(deployment, request))
-        else:
+
+        if not request.user.has_namespace(deployment.metadata.namespace):
             logger.warning(f"User '{request.user}' has no access to the namespace '{deployment.metadata.namespace}' of deployment '{deployment.metadata.uid}'. Access denied.")
             raise NotFound
 
+        pod_list = api.get_deployment_pods(deployment)
+        instance = DeploymentSerializer({
+            'name': deployment.metadata.name,
+            'uid': deployment.metadata.uid,
+            'creation_timestamp': deployment.metadata.creation_timestamp,
+            'replicas': deployment.spec.replicas,
+            'pod_urls': [reverse(viewname='pod', kwargs={'uid': pod.metadata.uid}, request=request) for pod in pod_list],
+            'namespace_url': reverse(viewname='namespace', kwargs={'namespace': deployment.metadata.namespace}, request=request)
+        })
+        return Response(instance.data)
 
-class DeploymentsView(generics.ListCreateAPIView):
+
+class DeploymentCreationView(generics.CreateAPIView):
     serializer_class = DeploymentSerializer
 
     @extend_schema(
-        summary="Get deployments in a namespace."
-    )
-    def get(self, request, version, namespace):
-        if request.user.has_namespace(namespace):
-            deployments = api.get_namespaced_deployments(namespace)
-            return Response([reverse(viewname='deployment', kwargs={'uid': deployment.metadata.uid}, request=request) for deployment in deployments])
-        else:
-            # https://lockmedown.com/when-should-you-return-404-instead-of-403-http-status-code/
-            logger.warning(f"User '{request.user}' has no access to deployments of the namespace '{namespace}'. Access denied.")
-            raise NotFound
-
-    @extend_schema(
-        summary="Create a deployment in a namespace."
+        summary="Create a deployment in a namespace.",
     )
     def post(self, request, version, namespace):
         if request.user.has_namespace(namespace):
             api.create_k8s_deployment(namespace,
                                       request.data["name"],
                                       request.data["replicas"],
-                                      request.data["matchLabels"],
-                                      request.data["template"])
+                                      request.data["match_labels"],
+                                      request.data["pod_template"])
             return Response(status=201)
         else:
             raise NotFound
+

--- a/kubeportal/api/views/info.py
+++ b/kubeportal/api/views/info.py
@@ -5,7 +5,6 @@ from rest_framework.response import Response
 from rest_framework import serializers
 from rest_framework.reverse import reverse
 
-
 from kubeportal.api.views.tools import get_user_count, get_kubeportal_version, get_cluster_name
 from kubeportal.k8s import kubernetes_api as api
 
@@ -75,6 +74,7 @@ class InfoDetailView(GenericAPIView):
         else:
             raise NotFound
 
+
 class InfoView(GenericAPIView):
 
     @extend_schema(
@@ -86,4 +86,3 @@ class InfoView(GenericAPIView):
         for info_slug in InfoDetailView.stats.keys():
             result[info_slug] = reverse(viewname='info_detail', kwargs={'info_slug': info_slug}, request=request)
         return Response({'info_urls': result})
-

--- a/kubeportal/api/views/info.py
+++ b/kubeportal/api/views/info.py
@@ -9,6 +9,14 @@ from rest_framework.reverse import reverse
 from kubeportal.api.views.tools import get_user_count, get_kubeportal_version, get_cluster_name
 from kubeportal.k8s import kubernetes_api as api
 
+
+class InfoListSerializer(serializers.Serializer):
+    """
+    The API serializer for a list of infos.
+    """
+    info_urls = serializers.DictField(read_only=True)
+
+
 class InfoDetailView(GenericAPIView):
     stats = {'k8s_version': api.get_kubernetes_version,
              'k8s_apiserver_url': api.get_apiserver,
@@ -67,13 +75,15 @@ class InfoDetailView(GenericAPIView):
         else:
             raise NotFound
 
-
 class InfoView(GenericAPIView):
+
+    @extend_schema(
+        summary="Get endpoints for retreiving information about the portal and the cluster.",
+        responses={200: InfoListSerializer}
+    )
     def get(self, request, version):
         result = {}
         for info_slug in InfoDetailView.stats.keys():
             result[info_slug] = reverse(viewname='info_detail', kwargs={'info_slug': info_slug}, request=request)
-        return Response({'links': result})
-
-
+        return Response({'info_urls': result})
 

--- a/kubeportal/api/views/ingresses.py
+++ b/kubeportal/api/views/ingresses.py
@@ -74,7 +74,7 @@ class IngressRetrievalView(generics.RetrieveAPIView):
         return Response(instance.data)
 
 
-class IngressCreationView(generics.UpdateAPIView):
+class IngressCreationView(generics.CreateAPIView):
     serializer_class = IngressSerializer
 
     @extend_schema(

--- a/kubeportal/api/views/ingresshosts.py
+++ b/kubeportal/api/views/ingresshosts.py
@@ -2,32 +2,22 @@ from drf_spectacular.utils import extend_schema
 from rest_framework.generics import GenericAPIView
 from rest_framework.response import Response
 from kubeportal.k8s import kubernetes_api as api
+from rest_framework import serializers, generics
+
+
+
+class IngressHostListSerializer(serializers.Serializer):
+    """
+    The API serializer for a list of ingress host names.
+    """
+    hosts = serializers.ListField(read_only=True, child=serializers.CharField())
 
 
 class IngressHostsView(GenericAPIView):
 
     @extend_schema(
-        operation={
-            "operationId": "get_ingresshosts",
-            "tags": ["api"],
-            "summary": "Get the list of host names used by ingresses in all namespaces.",
-            "security": [{"jwtAuth": []}],
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "type": "string",
-                                    "example": "app.example.com"
-                                    }
-                            }
-                        }
-                    }
-                }
-            }
-        }
+        summary="Get the list of host names used by ingresses in all namespaces.",
+        responses={200: IngressHostListSerializer}
     )
     def get(self, request, version):
-        return Response(api.get_ingress_hosts())
+        return Response({'hosts': api.get_ingress_hosts()})

--- a/kubeportal/api/views/ingresshosts.py
+++ b/kubeportal/api/views/ingresshosts.py
@@ -1,9 +1,9 @@
 from drf_spectacular.utils import extend_schema
+from rest_framework import serializers
 from rest_framework.generics import GenericAPIView
 from rest_framework.response import Response
-from kubeportal.k8s import kubernetes_api as api
-from rest_framework import serializers, generics
 
+from kubeportal.k8s import kubernetes_api as api
 
 
 class IngressHostListSerializer(serializers.Serializer):

--- a/kubeportal/api/views/login.py
+++ b/kubeportal/api/views/login.py
@@ -1,12 +1,9 @@
-from drf_spectacular.utils import OpenApiExample, extend_schema_serializer, extend_schema, extend_schema_field
+from dj_rest_auth.serializers import LoginSerializer as OriginalLoginSerializer
 from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import OpenApiExample, extend_schema_serializer, extend_schema_field
 from rest_framework import serializers
 from rest_framework.reverse import reverse
 
-
-from dj_rest_auth.serializers import LoginSerializer as OriginalLoginSerializer
-from django.conf import settings
-from django.utils.module_loading import import_string
 
 @extend_schema_serializer(
     examples=[
@@ -20,13 +17,14 @@ from django.utils.module_loading import import_string
         ),
     ]
 )
-class LoginSerializer(OriginalLoginSerializer): # remove third optional field from library
+class LoginSerializer(OriginalLoginSerializer):  # remove third optional field from library
     """
     The API serializer for username / password login.
     """
     username = serializers.CharField()
     password = serializers.CharField()
     email = None
+
 
 class JWTSerializer(serializers.Serializer):
     """
@@ -53,4 +51,3 @@ class JWTSerializer(serializers.Serializer):
     def get_infos_url(self, obj):
         request = self.context['request']
         return reverse(viewname='info_overview', request=request)
-

--- a/kubeportal/api/views/login.py
+++ b/kubeportal/api/views/login.py
@@ -1,4 +1,5 @@
-from drf_spectacular.utils import OpenApiExample, extend_schema_serializer, extend_schema
+from drf_spectacular.utils import OpenApiExample, extend_schema_serializer, extend_schema, extend_schema_field
+from drf_spectacular.types import OpenApiTypes
 from rest_framework import serializers
 from rest_framework.reverse import reverse
 
@@ -17,35 +18,39 @@ from django.utils.module_loading import import_string
             },
             request_only=True
         ),
-        OpenApiExample(
-            '',
-            value={
-                'user_id': 42,
-                'group_ids': [5,7,13],
-                'namespace': 'default',
-                'jwt': '89ew4z7ro9ew47reswu'
-            },
-            response_only=True
-        ),
     ]
 )
 class LoginSerializer(OriginalLoginSerializer): # remove third optional field from library
+    """
+    The API serializer for username / password login.
+    """
     username = serializers.CharField()
     password = serializers.CharField()
+    email = None
 
 class JWTSerializer(serializers.Serializer):
     """
-    Serializer for JWT authentication.
+    The API serializer for getting security information after successful login.
     """
     access_token = serializers.CharField()
     refresh_token = serializers.CharField()
-    links = serializers.SerializerMethodField()
+    user_url = serializers.SerializerMethodField()
+    news_url = serializers.SerializerMethodField()
+    infos_url = serializers.SerializerMethodField()
 
-    def get_links(self, obj):
+    @extend_schema_field(OpenApiTypes.URI)
+    def get_user_url(self, obj):
         uid = obj['user'].pk
         request = self.context['request']
-        return {'user': reverse(viewname='user', kwargs={'user_id': uid}, request=request),
-                'news': reverse(viewname='news', request=request),
-                'infos': reverse(viewname="info_overview", request=request)
-                }
+        return reverse(viewname='user', kwargs={'user_id': uid}, request=request)
+
+    @extend_schema_field(OpenApiTypes.URI)
+    def get_news_url(self, obj):
+        request = self.context['request']
+        return reverse(viewname='news', request=request)
+
+    @extend_schema_field(OpenApiTypes.URI)
+    def get_infos_url(self, obj):
+        request = self.context['request']
+        return reverse(viewname='info_overview', request=request)
 

--- a/kubeportal/api/views/namespaces.py
+++ b/kubeportal/api/views/namespaces.py
@@ -1,26 +1,83 @@
 from rest_framework import serializers, generics
 from rest_framework.reverse import reverse
+from drf_spectacular.utils import extend_schema_serializer, extend_schema_field
+from drf_spectacular.types import OpenApiTypes
 
 from kubeportal.models.kubernetesnamespace import KubernetesNamespace
 
+class DeploymentListSerializer(serializers.Serializer):
+    """
+    The API serializer for a list of deployments.
+    """
+    deployment_urls = serializers.ListField(read_only=True, child=serializers.URLField())
+
+
+class PodListSerializer(serializers.Serializer):
+    """
+    The API serializer for a list of pods.
+    """
+    pod_urls = serializers.ListField(read_only=True, child=serializers.URLField())
+
+
+class IngressListSerializer(serializers.Serializer):
+    """
+    The API serializer for a list of ingresses.
+    """
+    ingress_urls = serializers.ListField(read_only=True, child=serializers.URLField())
+
+class ServiceListSerializer(serializers.Serializer):
+    """
+    The API serializer for a list of services.
+    """
+    service_urls = serializers.ListField(read_only=True, child=serializers.URLField())
+
+
+class ServiceAccountListSerializer(serializers.Serializer):
+    """
+    The API serializer for a list of service accounts.
+    """
+    service_account_urls = serializers.HyperlinkedRelatedField(many=True, view_name='serviceaccount', lookup_url_kwarg='uid', lookup_field='service_accounts', read_only=True)
+
+
+class NamespaceLinksSerializer(DeploymentListSerializer, PodListSerializer, ServiceAccountListSerializer, ServiceListSerializer, IngressListSerializer):
+    pass
 
 class NamespaceSerializer(serializers.ModelSerializer):
-    pods = serializers.SerializerMethodField()
-    deployments = serializers.SerializerMethodField()
+    links = NamespaceLinksSerializer()
 
     class Meta:
         model = KubernetesNamespace
-        fields = ['name', 'pods', 'deployments']
+        fields = ['name', 'links']
 
-    def get_pods(self, obj):        
+    @extend_schema_field(PodListSerializer)
+    def get_pod_urls(self, obj):
         uids = obj.get_pod_uids()
         request = self.context['request']        
         return [reverse(viewname='pod', kwargs={'uid': uid}, request=request) for uid in uids]
 
-    def get_deployments(self, obj):        
+    @extend_schema_field(DeploymentListSerializer)
+    def get_deployment_urls(self, obj):        
         uids = obj.get_deployment_uids()
         request = self.context['request']        
         return [reverse(viewname='deployment', kwargs={'uid': uid}, request=request) for uid in uids]
+
+    @extend_schema_field(ServiceAccountListSerializer)
+    def get_service_account_urls(self, obj):        
+        uids = obj.get_deployment_uids()
+        request = self.context['request']        
+        return [reverse(viewname='deployment', kwargs={'uid': uid}, request=request) for uid in uids]
+
+    @extend_schema_field(IngressListSerializer)
+    def get_ingress_urls(self, obj):        
+        uids = obj.get_ingress_uids()
+        request = self.context['request']        
+        return [reverse(viewname='ingress', kwargs={'uid': uid}, request=request) for uid in uids]
+
+    @extend_schema_field(ServiceListSerializer)
+    def get_service_urls(self, obj):        
+        uids = obj.get_service_uids()
+        request = self.context['request']        
+        return [reverse(viewname='service', kwargs={'uid': uid}, request=request) for uid in uids]
 
 
 class NamespaceView(generics.RetrieveAPIView):

--- a/kubeportal/api/views/namespaces.py
+++ b/kubeportal/api/views/namespaces.py
@@ -5,48 +5,23 @@ from kubeportal.models.kubernetesnamespace import KubernetesNamespace
 
 
 class NamespaceSerializer(serializers.ModelSerializer):
-    deployment_urls = serializers.ListField(child=serializers.URLField(), read_only=True)
-    pod_urls = serializers.ListField(child=serializers.URLField(), read_only=True)
-    ingress_urls = serializers.ListField(child=serializers.URLField(), read_only=True)
-    service_urls = serializers.ListField(child=serializers.URLField(), read_only=True)
-    service_account_urls = serializers.HyperlinkedRelatedField(many=True,
-                                                               view_name='serviceaccount_retrieval',
-                                                               lookup_url_kwarg='uid',
-                                                               source='service_accounts',
-                                                               lookup_field='uid',
-                                                               read_only=True)
+    deployments_url = serializers.URLField(read_only=True)
+    pods_url = serializers.URLField(read_only=True)
+    ingresses_url = serializers.URLField(read_only=True)
+    services_url = serializers.URLField(read_only=True)
 
     class Meta:
         model = KubernetesNamespace
-        fields = ['name', 'deployment_urls', 'pod_urls', 'ingress_urls', 'service_urls', 'service_account_urls']
+        fields = ['name', 'deployments_url', 'pods_url', 'ingresses_url', 'services_url']
 
     def to_representation(self, instance):
         ret = super().to_representation(instance)
-        ret['deployment_urls'] = self.get_deployment_urls(instance)
-        ret['pod_urls'] = self.get_pod_urls(instance)
-        ret['ingress_urls'] = self.get_ingress_urls(instance)
-        ret['service_urls'] = self.get_service_urls(instance)
+        request = self.context['request']
+        ret['deployments_url'] = reverse(viewname='deployments', kwargs={'namespace': instance.name}, request=request)
+        ret['pods_url'] = reverse(viewname='pods', kwargs={'namespace': instance.name}, request=request)
+        ret['ingresses_url'] = reverse(viewname='ingresses', kwargs={'namespace': instance.name}, request=request)
+        ret['services_url'] = reverse(viewname='services', kwargs={'namespace': instance.name}, request=request)
         return ret
-
-    def get_deployment_urls(self, obj):
-        uids = obj.get_deployment_uids()
-        request = self.context['request']
-        return [reverse(viewname='deployment_retrieval', kwargs={'uid': uid}, request=request) for uid in uids]
-
-    def get_pod_urls(self, obj):
-        uids = obj.get_pod_uids()
-        request = self.context['request']
-        return [reverse(viewname='pod_retrieval', kwargs={'uid': uid}, request=request) for uid in uids]
-
-    def get_ingress_urls(self, obj):
-        uids = obj.get_ingress_uids()
-        request = self.context['request']
-        return [reverse(viewname='ingress_retrieval', kwargs={'uid': uid}, request=request) for uid in uids]
-
-    def get_service_urls(self, obj):
-        uids = obj.get_service_uids()
-        request = self.context['request']
-        return [reverse(viewname='service_retrieval', kwargs={'uid': uid}, request=request) for uid in uids]
 
 
 class NamespaceView(generics.RetrieveAPIView):

--- a/kubeportal/api/views/namespaces.py
+++ b/kubeportal/api/views/namespaces.py
@@ -1,83 +1,52 @@
 from rest_framework import serializers, generics
 from rest_framework.reverse import reverse
-from drf_spectacular.utils import extend_schema_serializer, extend_schema_field
-from drf_spectacular.types import OpenApiTypes
 
 from kubeportal.models.kubernetesnamespace import KubernetesNamespace
 
-class DeploymentListSerializer(serializers.Serializer):
-    """
-    The API serializer for a list of deployments.
-    """
-    deployment_urls = serializers.ListField(read_only=True, child=serializers.URLField())
-
-
-class PodListSerializer(serializers.Serializer):
-    """
-    The API serializer for a list of pods.
-    """
-    pod_urls = serializers.ListField(read_only=True, child=serializers.URLField())
-
-
-class IngressListSerializer(serializers.Serializer):
-    """
-    The API serializer for a list of ingresses.
-    """
-    ingress_urls = serializers.ListField(read_only=True, child=serializers.URLField())
-
-class ServiceListSerializer(serializers.Serializer):
-    """
-    The API serializer for a list of services.
-    """
-    service_urls = serializers.ListField(read_only=True, child=serializers.URLField())
-
-
-class ServiceAccountListSerializer(serializers.Serializer):
-    """
-    The API serializer for a list of service accounts.
-    """
-    service_account_urls = serializers.HyperlinkedRelatedField(many=True, view_name='serviceaccount', lookup_url_kwarg='uid', lookup_field='service_accounts', read_only=True)
-
-
-class NamespaceLinksSerializer(DeploymentListSerializer, PodListSerializer, ServiceAccountListSerializer, ServiceListSerializer, IngressListSerializer):
-    pass
 
 class NamespaceSerializer(serializers.ModelSerializer):
-    links = NamespaceLinksSerializer()
+    deployment_urls = serializers.ListField(child=serializers.URLField(), read_only=True)
+    pod_urls = serializers.ListField(child=serializers.URLField(), read_only=True)
+    ingress_urls = serializers.ListField(child=serializers.URLField(), read_only=True)
+    service_urls = serializers.ListField(child=serializers.URLField(), read_only=True)
+    service_account_urls = serializers.HyperlinkedRelatedField(many=True,
+                                                               view_name='serviceaccount_retrieval',
+                                                               lookup_url_kwarg='uid',
+                                                               source='service_accounts',
+                                                               lookup_field='uid',
+                                                               read_only=True)
 
     class Meta:
         model = KubernetesNamespace
-        fields = ['name', 'links']
+        fields = ['name', 'deployment_urls', 'pod_urls', 'ingress_urls', 'service_urls', 'service_account_urls']
 
-    @extend_schema_field(PodListSerializer)
+    def to_representation(self, instance):
+        ret = super().to_representation(instance)
+        ret['deployment_urls'] = self.get_deployment_urls(instance)
+        ret['pod_urls'] = self.get_pod_urls(instance)
+        ret['ingress_urls'] = self.get_ingress_urls(instance)
+        ret['service_urls'] = self.get_service_urls(instance)
+        return ret
+
+    def get_deployment_urls(self, obj):
+        uids = obj.get_deployment_uids()
+        request = self.context['request']
+        return [reverse(viewname='deployment_retrieval', kwargs={'uid': uid}, request=request) for uid in uids]
+
     def get_pod_urls(self, obj):
         uids = obj.get_pod_uids()
-        request = self.context['request']        
-        return [reverse(viewname='pod', kwargs={'uid': uid}, request=request) for uid in uids]
+        request = self.context['request']
+        return [reverse(viewname='pod_retrieval', kwargs={'uid': uid}, request=request) for uid in uids]
 
-    @extend_schema_field(DeploymentListSerializer)
-    def get_deployment_urls(self, obj):        
-        uids = obj.get_deployment_uids()
-        request = self.context['request']        
-        return [reverse(viewname='deployment', kwargs={'uid': uid}, request=request) for uid in uids]
-
-    @extend_schema_field(ServiceAccountListSerializer)
-    def get_service_account_urls(self, obj):        
-        uids = obj.get_deployment_uids()
-        request = self.context['request']        
-        return [reverse(viewname='deployment', kwargs={'uid': uid}, request=request) for uid in uids]
-
-    @extend_schema_field(IngressListSerializer)
-    def get_ingress_urls(self, obj):        
+    def get_ingress_urls(self, obj):
         uids = obj.get_ingress_uids()
-        request = self.context['request']        
-        return [reverse(viewname='ingress', kwargs={'uid': uid}, request=request) for uid in uids]
+        request = self.context['request']
+        return [reverse(viewname='ingress_retrieval', kwargs={'uid': uid}, request=request) for uid in uids]
 
-    @extend_schema_field(ServiceListSerializer)
-    def get_service_urls(self, obj):        
+    def get_service_urls(self, obj):
         uids = obj.get_service_uids()
-        request = self.context['request']        
-        return [reverse(viewname='service', kwargs={'uid': uid}, request=request) for uid in uids]
+        request = self.context['request']
+        return [reverse(viewname='service_retrieval', kwargs={'uid': uid}, request=request) for uid in uids]
 
 
 class NamespaceView(generics.RetrieveAPIView):

--- a/kubeportal/api/views/news.py
+++ b/kubeportal/api/views/news.py
@@ -5,15 +5,17 @@ from kubeportal.models.news import News
 
 
 class NewsSerializer(serializers.ModelSerializer):
+    author_url = serializers.URLField()
+
     class Meta:
         model = News
-        fields = ['title', 'content', 'author', 'created', 'modified', 'priority']
+        fields = ['title', 'content', 'author_url', 'created', 'modified', 'priority']
 
     def to_representation(self, data):
         data = super(NewsSerializer, self).to_representation(data)
         request = self.context['request']
         author_url = reverse(viewname='user', kwargs={'user_id': data['author']}, request=request)
-        data['author'] = author_url
+        data['author_url'] = author_url
         return data
 
 

--- a/kubeportal/api/views/news.py
+++ b/kubeportal/api/views/news.py
@@ -11,11 +11,10 @@ class NewsSerializer(serializers.ModelSerializer):
         model = News
         fields = ['title', 'content', 'author_url', 'created', 'modified', 'priority']
 
-    def to_representation(self, data):
-        data = super(NewsSerializer, self).to_representation(data)
+    def to_representation(self, instance):
         request = self.context['request']
-        author_url = reverse(viewname='user', kwargs={'user_id': data['author']}, request=request)
-        data['author_url'] = author_url
+        instance.author_url = reverse(viewname='user', kwargs={'user_id': instance.author.pk}, request=request)
+        data = super().to_representation(instance)
         return data
 
 

--- a/kubeportal/api/views/pods.py
+++ b/kubeportal/api/views/pods.py
@@ -7,6 +7,7 @@ from rest_framework.reverse import reverse
 from kubeportal.k8s import kubernetes_api as api
 
 import logging
+
 logger = logging.getLogger('KubePortal')
 
 
@@ -16,6 +17,7 @@ class ContainerSerializer(serializers.Serializer):
     """
     name = serializers.CharField()
     image = serializers.CharField()
+
 
 class PodSerializer(serializers.Serializer):
     """
@@ -54,7 +56,6 @@ class PodRetrievalView(generics.RetrieveAPIView):
         if request.user.has_namespace(pod.metadata.namespace):
             return Response(PodSerializer.to_json(pod))
         else:
-            logger.warning(f"User '{request.user}' has no access to the namespace '{pod.metadata.namespace}' of pod '{pod.metadata.uid}'. Access denied.")
+            logger.warning(
+                f"User '{request.user}' has no access to the namespace '{pod.metadata.namespace}' of pod '{pod.metadata.uid}'. Access denied.")
             raise NotFound
-
-

--- a/kubeportal/api/views/serviceaccounts.py
+++ b/kubeportal/api/views/serviceaccounts.py
@@ -6,8 +6,8 @@ from kubeportal.models.kubernetesserviceaccount import KubernetesServiceAccount
 class ServiceAccountSerializer(serializers.ModelSerializer):
     name = serializers.CharField()
     uid = serializers.CharField(read_only=True)
-    namespace = serializers.HyperlinkedRelatedField(view_name='namespace', lookup_field='name', lookup_url_kwarg='namespace', read_only=True)
-
+    namespace = serializers.HyperlinkedRelatedField(view_name='namespace', lookup_field='name',
+                                                    lookup_url_kwarg='namespace', read_only=True)
 
     class Meta:
         model = KubernetesServiceAccount
@@ -21,5 +21,3 @@ class ServiceAccountRetrievalView(generics.RetrieveAPIView):
     def get_queryset(self):
         # Clients can only request details of the service accounts that are assigned to them
         return self.request.user.k8s_accounts()
-
-

--- a/kubeportal/api/views/serviceaccounts.py
+++ b/kubeportal/api/views/serviceaccounts.py
@@ -14,7 +14,7 @@ class ServiceAccountSerializer(serializers.ModelSerializer):
         fields = ['name', 'uid', 'namespace']
 
 
-class ServiceAccountView(generics.RetrieveAPIView):
+class ServiceAccountRetrievalView(generics.RetrieveAPIView):
     lookup_field = 'uid'
     serializer_class = ServiceAccountSerializer
 
@@ -23,5 +23,3 @@ class ServiceAccountView(generics.RetrieveAPIView):
         return self.request.user.k8s_accounts()
 
 
-class ServiceAccountsView(generics.ListAPIView):
-    serializer_class = ServiceAccountSerializer

--- a/kubeportal/api/views/services.py
+++ b/kubeportal/api/views/services.py
@@ -56,12 +56,17 @@ class ServiceRetrievalView(generics.RetrieveAPIView):
                 f"User '{request.user}' has no access to the namespace '{service.metadata.namespace}' of service '{service.metadata.uid}'. Access denied.")
             raise NotFound
 
+        if service.spec.selector:
+            selector = {'key': list(service.spec.selector.keys())[0],
+                        'value': list(service.spec.selector.values())[0]} 
+        else:
+            selector = None
+
         instance = ServiceSerializer({
             'name': service.metadata.name,
             'creation_timestamp': service.metadata.creation_timestamp,
             'type': service.spec.type,
-            'selector': {'key': list(service.spec.selector.keys())[0],
-                         'value': list(service.spec.selector.values())[0]},
+            'selector': selector,
             'ports': [{'port': item.port, 'target_port': item.target_port, 'protocol': item.protocol} for item in
                       service.spec.ports]
         })

--- a/kubeportal/api/views/users.py
+++ b/kubeportal/api/views/users.py
@@ -16,7 +16,7 @@ class UserSerializer(serializers.ModelSerializer):
     primary_email = serializers.EmailField(source='email')
     admin = serializers.BooleanField(source='is_staff', read_only=True)
     all_emails = serializers.ListField(read_only=True)
-    k8s_accounts = serializers.HyperlinkedRelatedField(many=True, view_name='serviceaccount', lookup_url_kwarg='uid', lookup_field='uid', read_only=True)
+    k8s_accounts = serializers.HyperlinkedRelatedField(many=True, view_name='serviceaccount_retrieval', lookup_url_kwarg='uid', lookup_field='uid', read_only=True)
     k8s_namespaces = serializers.HyperlinkedRelatedField(many=True, view_name='namespace', lookup_url_kwarg='namespace', lookup_field='name', read_only=True)
     k8s_namespace_names = serializers.ListField(read_only=True)
     k8s_token = serializers.CharField(source='token', read_only=True)

--- a/kubeportal/api/views/users.py
+++ b/kubeportal/api/views/users.py
@@ -35,7 +35,9 @@ class UserSerializer(serializers.ModelSerializer):
                                                          lookup_field='name',
                                                          read_only=True,
                                                          source='k8s_namespaces')
-    namespace_names = serializers.ListField(read_only=True)
+    namespace_names = serializers.ListField(read_only=True, 
+                                            child=serializers.CharField(),
+                                            source='k8s_namespace_names')
     k8s_token = serializers.CharField(source='token', read_only=True)
 
     class Meta:

--- a/kubeportal/api/views/users.py
+++ b/kubeportal/api/views/users.py
@@ -5,9 +5,16 @@ from kubeportal.api.views.tools import User
 
 
 class UserSerializer(serializers.ModelSerializer):
-    portal_groups = serializers.HyperlinkedRelatedField(many=True, view_name='group', lookup_url_kwarg='group_id',
-                                                        read_only=True)
-    webapps = serializers.HyperlinkedRelatedField(many=True, view_name='webapplication', lookup_url_kwarg='webapp_id', read_only=True)
+    group_urls = serializers.HyperlinkedRelatedField(many=True,
+                                                     view_name='group',
+                                                     lookup_url_kwarg='group_id',
+                                                     read_only=True,
+                                                     source='portal_groups')
+    webapp_urls = serializers.HyperlinkedRelatedField(many=True,
+                                                      view_name='webapplication',
+                                                      lookup_url_kwarg='webapp_id',
+                                                      read_only=True,
+                                                      source='webapps')
     firstname = serializers.CharField(source='first_name')
     name = serializers.CharField(source='last_name')
     state = serializers.CharField(read_only=True)
@@ -16,15 +23,25 @@ class UserSerializer(serializers.ModelSerializer):
     primary_email = serializers.EmailField(source='email')
     admin = serializers.BooleanField(source='is_staff', read_only=True)
     all_emails = serializers.ListField(read_only=True)
-    k8s_accounts = serializers.HyperlinkedRelatedField(many=True, view_name='serviceaccount_retrieval', lookup_url_kwarg='uid', lookup_field='uid', read_only=True)
-    k8s_namespaces = serializers.HyperlinkedRelatedField(many=True, view_name='namespace', lookup_url_kwarg='namespace', lookup_field='name', read_only=True)
-    k8s_namespace_names = serializers.ListField(read_only=True)
+    serviceaccount_urls = serializers.HyperlinkedRelatedField(many=True,
+                                                              view_name='serviceaccount_retrieval',
+                                                              lookup_url_kwarg='uid',
+                                                              lookup_field='uid',
+                                                              read_only=True,
+                                                              source='k8s_accounts')
+    namespace_urls = serializers.HyperlinkedRelatedField(many=True,
+                                                         view_name='namespace',
+                                                         lookup_url_kwarg='namespace',
+                                                         lookup_field='name',
+                                                         read_only=True,
+                                                         source='k8s_namespaces')
+    namespace_names = serializers.ListField(read_only=True)
     k8s_token = serializers.CharField(source='token', read_only=True)
 
     class Meta:
         model = User
-        fields = ('portal_groups',
-                  'webapps',
+        fields = ('group_urls',
+                  'webapp_urls',
                   'firstname',
                   'name',
                   'username',
@@ -33,9 +50,9 @@ class UserSerializer(serializers.ModelSerializer):
                   'admin',
                   'state',
                   'all_emails',
-                  'k8s_accounts',
-                  'k8s_namespaces',
-                  'k8s_namespace_names',
+                  'serviceaccount_urls',
+                  'namespace_urls',
+                  'namespace_names',
                   'k8s_token')
 
 

--- a/kubeportal/models/kubernetesnamespace.py
+++ b/kubeportal/models/kubernetesnamespace.py
@@ -72,6 +72,22 @@ class KubernetesNamespace(models.Model):
         return [item.metadata.uid for item in deployments]
 
 
+    def get_service_uids(self):
+        """
+        Get UIDs of the services in this namespace.
+        """
+        services = api.get_namespaced_services(self.name)
+        return [item.metadata.uid for item in services]
+
+
+    def get_ingress_uids(self):
+        """
+        Get UIDs of the ingresses in this namespace.
+        """
+        ingresses = api.get_namespaced_ingresses(self.name)
+        return [item.metadata.uid for item in ingresses]
+
+
     @classmethod
     def create_missing_in_portal(cls):
         """

--- a/kubeportal/tests/fixtures/ingress1.yml
+++ b/kubeportal/tests/fixtures/ingress1.yml
@@ -1,16 +1,20 @@
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
-  name: test-ingress-1
+  name: test-ingress-1b
   namespace: default
+  annotations:
+    foo: bar
 spec:
-   rules:
-   - host: "visbert.demo.datexis.com"
-     http:
-       paths:
-       - path:
-         backend:
-           serviceName: visbert
-           servicePort: 1337
-
-
+  tls:
+  - secretName: "visbert-demo-subdomain-tls"
+    hosts:
+    - "visbert.demo.datexis.com"
+  rules:
+  - host: "visbert.demo.datexis.com"
+    http:
+      paths:
+      - path:
+        backend:
+          serviceName: visbert
+          servicePort: 1337

--- a/kubeportal/tests/fixtures/service1.yml
+++ b/kubeportal/tests/fixtures/service1.yml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: service1
+  namespace: default
+spec:
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 9376

--- a/kubeportal/tests/test_api.py
+++ b/kubeportal/tests/test_api.py
@@ -31,7 +31,7 @@ def test_api_bootstrap(api_client_anon):
     assert 'links' in data
     # check if given login route makes sense
     # login path response tells us to use something else than GET
-    response = api_client_anon.get_absolute(data['links']['login'])
+    response = api_client_anon.get_absolute(data['links']['login_url'])
     assert response.status_code == 405
 
 

--- a/kubeportal/tests/test_api.py
+++ b/kubeportal/tests/test_api.py
@@ -26,12 +26,13 @@ def test_api_bootstrap(api_client_anon):
     response = api_client_anon.get(f'/api/{settings.API_VERSION}/')
     assert response.status_code == 200
     data = response.json()
-    assert 2 == len(data)
     assert 'csrf_token' in data
-    assert 'links' in data
+    assert 'login_url' in data
+    assert 'logout_url' in data
+    assert 'login_google_url' in data
     # check if given login route makes sense
     # login path response tells us to use something else than GET
-    response = api_client_anon.get_absolute(data['links']['login_url'])
+    response = api_client_anon.get_absolute(data['login_url'])
     assert response.status_code == 405
 
 

--- a/kubeportal/tests/test_api_cluster.py
+++ b/kubeportal/tests/test_api_cluster.py
@@ -7,14 +7,14 @@ from kubeportal.api.views import InfoDetailView
 @pytest.mark.django_db
 def test_cluster_denied(api_client_anon):
     for stat in InfoDetailView.stats.keys():
-        response = api_client_anon.get(f'/api/{settings.API_VERSION}/info/{stat}/')
+        response = api_client_anon.get(f'/api/{settings.API_VERSION}/infos/{stat}/')
         assert response.status_code == 401
 
 
 @pytest.mark.skipif(minikube_unavailable(), reason="Minikube is unavailable")
 def test_cluster(api_client):
     for stat in InfoDetailView.stats.keys():
-        response = api_client.get(f'/api/{settings.API_VERSION}/info/{stat}/')
+        response = api_client.get(f'/api/{settings.API_VERSION}/infos/{stat}/')
         assert 200 == response.status_code
         data = response.json()
         assert stat in data.keys()
@@ -22,5 +22,5 @@ def test_cluster(api_client):
 
 
 def test_cluster_invalid(api_client):
-    response = api_client.get(f'/api/{settings.API_VERSION}/info/foobar/')
+    response = api_client.get(f'/api/{settings.API_VERSION}/infos/foobar/')
     assert response.status_code == 404

--- a/kubeportal/tests/test_api_deployments.py
+++ b/kubeportal/tests/test_api_deployments.py
@@ -25,10 +25,17 @@ def test_namespace_deployments_list(api_client, admin_user):
     assert 200 == response.status_code
     response_data = json.loads(response.content)
     assert len(response_data) > 0
-    deployments = response_data['deployment_urls']
+    deployments_url = response_data['deployments_url']
+
+    # fetch list of deployments
+    response = api_client.get_absolute(deployments_url)
+    assert 200 == response.status_code
+    response_data = json.loads(response.content)
+    assert len(response_data) > 0
+    deployment_urls = response_data['deployment_urls']
 
     # fetch first deployment info
-    response = api_client.get_absolute(deployments[0])
+    response = api_client.get_absolute(deployment_urls[0])
     assert 200 == response.status_code
     deployment = json.loads(response.content)
     assert "coredns" in deployment['name']

--- a/kubeportal/tests/test_api_ingresses.py
+++ b/kubeportal/tests/test_api_ingresses.py
@@ -93,12 +93,18 @@ def test_user_ingresses_list(api_client, admin_user_with_k8s):
     response = api_client.get(f'/api/{settings.API_VERSION}/namespaces/default/')
     assert 200 == response.status_code
     data = json.loads(response.content)
-    ingress_urls = data['ingress_urls']
     from urllib.parse import urlparse
-    ingress = urlparse(ingress_urls[0])
-    response = api_client.get(ingress.path)
+    ingresses_url = urlparse(data['ingresses_url'])
+
+    response = api_client.get(ingresses_url.path)
     assert 200 == response.status_code
     data = json.loads(response.content)
+    ingress_url = urlparse(data['ingress_urls'][0])
+
+    response = api_client.get(ingress_url.path)
+    assert 200 == response.status_code
+    data = json.loads(response.content)
+
     assert "test-ingress-1b" == data['name']
     assert data['tls'] is True
     assert "visbert" in data["rules"][0]["host"]

--- a/kubeportal/tests/test_api_news.py
+++ b/kubeportal/tests/test_api_news.py
@@ -14,4 +14,4 @@ def test_news_list(api_client, admin_user):
     data = json.loads(response.content)
     assert "<p>Hello World</p>" == data[0]["content"]
     assert "Foo" == data[0]["title"]
-    assert data[0]["author"].endswith(f"/{admin_user.pk}/")
+    assert data[0]["author_url"].endswith(f"/{admin_user.pk}/")

--- a/kubeportal/tests/test_api_pods.py
+++ b/kubeportal/tests/test_api_pods.py
@@ -19,8 +19,14 @@ def test_namespace_pods_list(api_client, admin_user):
     assert 200 == response.status_code
     data = json.loads(response.content)
     assert len(data) > 0
-    pods_list = data["pod_urls"]
-    assert pods_list[0].startswith("http://testserver")
+    from urllib.parse import urlparse
+    pods_url = urlparse(data["pods_url"])
+    response = api_client.get(pods_url.path)
+    assert 200 == response.status_code
+    data = json.loads(response.content)
+    assert len(data) > 0
+    pod_urls = data["pod_urls"]
+    assert pod_urls[0].startswith("http")
 
 
 @pytest.mark.skipif(minikube_unavailable(), reason="Minikube is unavailable")
@@ -73,6 +79,6 @@ def test_get_illegal_pod(api_client, admin_user):
     assert 404 == response.status_code
 
 
-def test_namespace_pods_list_no_k8s(api_client):
-    response = api_client.get(f'/api/{settings.API_VERSION}/namespaces/default/pods/')
-    assert 404 == response.status_code
+def test_namespace_pods_list_forbidden(api_client):
+    response = api_client.get(f'/api/{settings.API_VERSION}/namespaces/kube-system/pods/')
+    assert response.status_code == 404

--- a/kubeportal/tests/test_api_pods.py
+++ b/kubeportal/tests/test_api_pods.py
@@ -8,12 +8,6 @@ from kubeportal.models import KubernetesNamespace
 from kubeportal.tests.helpers import run_minikube_sync, minikube_unavailable
 
 
-@pytest.mark.django_db
-def test_pods_denied(api_client_anon):
-    response = api_client_anon.get(f'/api/{settings.API_VERSION}/namespaces/kube-system/pods/')
-    assert response.status_code == 401
-
-
 @pytest.mark.skipif(minikube_unavailable(), reason="Minikube is unavailable")
 def test_namespace_pods_list(api_client, admin_user):
     run_minikube_sync()
@@ -21,41 +15,59 @@ def test_namespace_pods_list(api_client, admin_user):
     admin_user.service_account = system_namespace.service_accounts.all()[0]
     admin_user.save()
 
-    response = api_client.get(f'/api/{settings.API_VERSION}/namespaces/foobar/pods/')
-    assert 404 == response.status_code
-
-    response = api_client.get(f'/api/{settings.API_VERSION}/namespaces/kube-system/pods/')
+    response = api_client.get(f'/api/{settings.API_VERSION}/namespaces/kube-system/')
     assert 200 == response.status_code
     data = json.loads(response.content)
-    assert len(data) > 0   # set of hyperlinks to pods
-    assert data[0].startswith("http://testserver")
+    assert len(data) > 0
+    pods_list = data["pod_urls"]
+    assert pods_list[0].startswith("http://testserver")
 
 
 @pytest.mark.skipif(minikube_unavailable(), reason="Minikube is unavailable")
 def test_get_pod(api_client, admin_user):
     run_minikube_sync()
+
+    # Minikube system pod names differ, depending on the version
+    pods = api.get_namespaced_pods("kube-system")
+    test_pod_name = None
+    for k8s_pod in pods:
+        if "apiserver" in k8s_pod.metadata.name:
+            test_pod_name = k8s_pod.metadata.name
+            break
+    assert test_pod_name
+
     system_namespace = KubernetesNamespace.objects.get(name="kube-system")
     admin_user.service_account = system_namespace.service_accounts.all()[0]
     admin_user.save()
 
-    pod = api.core_v1.read_namespaced_pod('kube-apiserver-minikube', 'kube-system')
+    pod = api.core_v1.read_namespaced_pod(test_pod_name, 'kube-system')
 
     response = api_client.get(f'/api/{settings.API_VERSION}/pods/{pod.metadata.uid}/')
     assert 200 == response.status_code
     data = json.loads(response.content)
-    assert data['name'] == 'kube-apiserver-minikube'
+    assert data['name'] == test_pod_name
     assert data['containers'][0]['name'] == 'kube-apiserver'
 
 
 @pytest.mark.skipif(minikube_unavailable(), reason="Minikube is unavailable")
 def test_get_illegal_pod(api_client, admin_user):
     run_minikube_sync()
+
+    # Minikube system pod names differ, depending on the version
+    pods = api.get_namespaced_pods("kube-system")
+    test_pod_name = None
+    for k8s_pod in pods:
+        if "apiserver" in k8s_pod.metadata.name:
+            test_pod_name = k8s_pod.metadata.name
+            break
+    assert test_pod_name
+
     system_namespace = KubernetesNamespace.objects.get(name="kube-system")
     default_namespace = KubernetesNamespace.objects.get(name="default")
     admin_user.service_account = default_namespace.service_accounts.all()[0]
     admin_user.save()
 
-    pod = api.core_v1.read_namespaced_pod('kube-apiserver-minikube', 'kube-system')
+    pod = api.core_v1.read_namespaced_pod(test_pod_name, 'kube-system')
 
     response = api_client.get(f'/api/{settings.API_VERSION}/pods/{pod.metadata.uid}/')
     assert 404 == response.status_code

--- a/kubeportal/tests/test_api_security.py
+++ b/kubeportal/tests/test_api_security.py
@@ -16,11 +16,12 @@ def test_api_login(api_client_anon, admin_user):
     # self.assertEqual(cookie['kubeportal-auth']['samesite'], 'Lax,')
     # self.assertEqual(cookie['kubeportal-auth']['httponly'], True)
     data = response.json()
-    assert 3 == len(data)
-    assert 'links' in data
     assert 'access_token' in data
     assert 'refresh_token' in data
-    assert str(admin_user.pk) in data['links']['user']
+    assert str(admin_user.pk) in data['user_url']
+    assert data['user_url'].startswith("http")
+    assert data['news_url'].startswith("http")
+    assert data['infos_url'].startswith("http")
 
 
 @pytest.mark.django_db
@@ -39,7 +40,7 @@ def test_js_api_bearer_auth(api_client):
     del (api_client.client.cookies['kubeportal-auth'])
     # Simulate JS code calling, add Bearer token
     headers = {'Origin': 'http://testserver', 'Authorization': f'Bearer {api_client.jwt}'}
-    response = api_client.get(f'/api/{settings.API_VERSION}/info/portal_version/', headers=headers)
+    response = api_client.get(f'/api/{settings.API_VERSION}/infos/portal_version/', headers=headers)
     assert response.status_code == 200
 
 

--- a/kubeportal/tests/test_api_security.py
+++ b/kubeportal/tests/test_api_security.py
@@ -48,7 +48,7 @@ def test_options_preflight_without_auth(api_client_anon, admin_user, admin_group
                  (f'/api/{settings.API_VERSION}/users/{admin_user.pk}', 'GET'),
                  (f'/api/{settings.API_VERSION}/users/{admin_user.pk}', 'PATCH'),
                  (f'/api/{settings.API_VERSION}/groups/{admin_group.pk}', 'GET'),
-                 (f'/api/{settings.API_VERSION}/info/k8s_apiserver', 'GET'),
+                 (f'/api/{settings.API_VERSION}/infos/k8s_apiserver', 'GET'),
                  (f'/api/{settings.API_VERSION}/login/', 'POST'),
                  ]
     for path, request_method in test_path:

--- a/kubeportal/tests/test_api_services.py
+++ b/kubeportal/tests/test_api_services.py
@@ -55,14 +55,19 @@ def test_user_services_list(api_client, admin_user):
     response = api_client.get(f'/api/{settings.API_VERSION}/namespaces/kube-system/')
     assert 200 == response.status_code
     data = json.loads(response.content)
-    services = data["service_urls"]
 
-    # fetch details of DNS service
     from urllib.parse import urlparse
-    service = urlparse(services[0])
-    response = api_client.get(service.path)
+    services_url = urlparse(data["services_url"])
+
+    response = api_client.get(services_url.path)
     assert 200 == response.status_code
     data = json.loads(response.content)
+    service_url = urlparse(data["service_urls"][0])
+
+    response = api_client.get(service_url.path)
+    assert 200 == response.status_code
+    data = json.loads(response.content)
+
     assert "kube-dns" == data['name']
     assert "ClusterIP" == data['type']
     assert 53 == data['ports'][0]['port']

--- a/kubeportal/tests/test_api_users.py
+++ b/kubeportal/tests/test_api_users.py
@@ -104,5 +104,5 @@ def test_no_general_user_list(api_client):
 
 
 def test_user_services_list_no_k8s(api_client):
-    response = api_client.get(f'/api/{settings.API_VERSION}/namespaces/default/services/')
+    response = api_client.post(f'/api/{settings.API_VERSION}/namespaces/default/services/')
     assert 404 == response.status_code

--- a/kubeportal/tests/test_api_users.py
+++ b/kubeportal/tests/test_api_users.py
@@ -24,10 +24,10 @@ def test_user(api_client, admin_user_with_k8s_system):
         'primary_email',
         'all_emails',
         'admin',
-        'k8s_accounts',
+        'serviceaccount_urls',
         'k8s_token',
-        'webapps',
-        'portal_groups'
+        'webapp_urls',
+        'group_urls'
     ]
 
     response = api_client.get(f'/api/{settings.API_VERSION}/users/{admin_user_with_k8s_system.pk}/')
@@ -39,10 +39,11 @@ def test_user(api_client, admin_user_with_k8s_system):
     for key in user_attr_expected:
         assert key in data
 
-    assert len(data["portal_groups"]) > 0   # all users group, at least
-    assert "http://testserver/api/" in data["portal_groups"][0]
+    assert len(data["group_urls"]) > 0   # all users group, at least
+    assert len(data["serviceaccount_urls"]) > 0
     assert data['all_emails'] == ['admin@example.com']
-    assert data['k8s_accounts'][0].startswith("http://testserver")
+    assert data['serviceaccount_urls'][0].startswith("http://testserver")
+    assert data['group_urls'][0].startswith("http://testserver")
 
 
 def test_patch_user(api_client, admin_user):

--- a/kubeportal/urls.py
+++ b/kubeportal/urls.py
@@ -57,16 +57,16 @@ urlpatterns = [
     # path('api/<str:version>/namespaces/<str:namespace>/serviceaccounts/', api_views.ServiceAccountCreationView.as_view(), name='serviceaccount_creation'),
     path('api/<str:version>/serviceaccounts/<str:uid>/', api_views.ServiceAccountRetrievalView.as_view(), name='serviceaccount_retrieval'),
 
-    path('api/<str:version>/namespaces/<str:namespace>/deployments/', api_views.DeploymentCreationView.as_view(), name='deployment_creation'),
+    path('api/<str:version>/namespaces/<str:namespace>/deployments/', api_views.DeploymentsView.as_view(), name='deployments'),
     path('api/<str:version>/deployments/<str:uid>/', api_views.DeploymentRetrievalView.as_view(), name='deployment_retrieval'),
 
-    # path('api/<str:version>/namespaces/<str:namespace>/pods/', api_views.PodCreationView.as_view(), name='pod_creation'),
+    path('api/<str:version>/namespaces/<str:namespace>/pods/', api_views.PodsView.as_view(), name='pods'),
     path('api/<str:version>/pods/<str:uid>/', api_views.PodRetrievalView.as_view(), name='pod_retrieval'),
 
-    path('api/<str:version>/namespaces/<str:namespace>/services/', api_views.ServiceCreationView.as_view(), name='service_creation'),
+    path('api/<str:version>/namespaces/<str:namespace>/services/', api_views.ServicesView.as_view(), name='services'),
     path('api/<str:version>/services/<str:uid>/', api_views.ServiceRetrievalView.as_view(), name='service_retrieval'),
 
-    path('api/<str:version>/namespaces/<str:namespace>/ingresses/', api_views.IngressCreationView.as_view(), name='ingress_creation'),
+    path('api/<str:version>/namespaces/<str:namespace>/ingresses/', api_views.IngressesView.as_view(), name='ingresses'),
     path('api/<str:version>/ingresses/<str:uid>/', api_views.IngressRetrievalView.as_view(), name='ingress_retrieval'),
 
     path('api/<str:version>/login/', dj_rest_views.LoginView.as_view(), name='rest_login'),

--- a/kubeportal/urls.py
+++ b/kubeportal/urls.py
@@ -38,29 +38,40 @@ urlpatterns = [
     path('api/docs/', SpectacularSwaggerView.as_view(url_name='schema'), name='swagger-ui'),
 
     path('api/<str:version>/', api_views.BootstrapInfoView.as_view()),
+
     path('api/<str:version>/users/<int:user_id>/', api_views.UserView.as_view(), name='user'),
+
     path('api/<str:version>/namespaces/<str:namespace>/', api_views.NamespaceView.as_view(), name='namespace'),
-    path('api/<str:version>/namespaces/<str:namespace>/serviceaccounts/', api_views.ServiceAccountsView.as_view(), name='serviceaccounts'),
-    path('api/<str:version>/serviceaccounts/<str:uid>/', api_views.ServiceAccountView.as_view(), name='serviceaccount'),
-    path('api/<str:version>/namespaces/<str:namespace>/deployments/', api_views.DeploymentsView.as_view(), name='deployments'),
-    path('api/<str:version>/deployments/<str:uid>/', api_views.DeploymentView.as_view(), name='deployment'),
-    path('api/<str:version>/namespaces/<str:namespace>/pods/', api_views.PodsView.as_view(), name='pods'),
-    path('api/<str:version>/pods/<str:uid>/', api_views.PodView.as_view(), name='pod'),
-    path('api/<str:version>/namespaces/<str:namespace>/services/', api_views.ServicesView.as_view(), name='services'),
-    path('api/<str:version>/services/<str:uid>/', api_views.ServiceView.as_view(), name='service'),
-    path('api/<str:version>/namespaces/<str:namespace>/ingresses/', api_views.IngressesView.as_view(), name='ingresses'),
-    path('api/<str:version>/ingresses/<str:uid>/', api_views.IngressView.as_view(), name='ingress'),
+
     path('api/<str:version>/ingresshosts/', api_views.IngressHostsView.as_view()),
 
+    path('api/<str:version>/infos/', api_views.InfoView.as_view(), name='info_overview'),
+    path('api/<str:version>/infos/<str:info_slug>/', api_views.InfoDetailView.as_view(), name='info_detail'),
+
+    path('api/<str:version>/news/', api_views.NewsView.as_view(), name='news'),
+
     path('api/<str:version>/groups/<int:group_id>/', api_views.GroupView.as_view(), name='group'),
+
     path('api/<str:version>/webapps/<int:webapp_id>/', api_views.WebAppView.as_view(), name='webapplication'),
+
+    # path('api/<str:version>/namespaces/<str:namespace>/serviceaccounts/', api_views.ServiceAccountCreationView.as_view(), name='serviceaccount_creation'),
+    path('api/<str:version>/serviceaccounts/<str:uid>/', api_views.ServiceAccountRetrievalView.as_view(), name='serviceaccount_retrieval'),
+
+    path('api/<str:version>/namespaces/<str:namespace>/deployments/', api_views.DeploymentCreationView.as_view(), name='deployment_creation'),
+    path('api/<str:version>/deployments/<str:uid>/', api_views.DeploymentRetrievalView.as_view(), name='deployment_retrieval'),
+
+    # path('api/<str:version>/namespaces/<str:namespace>/pods/', api_views.PodCreationView.as_view(), name='pod_creation'),
+    path('api/<str:version>/pods/<str:uid>/', api_views.PodRetrievalView.as_view(), name='pod_retrieval'),
+
+    path('api/<str:version>/namespaces/<str:namespace>/services/', api_views.ServiceCreationView.as_view(), name='service_creation'),
+    path('api/<str:version>/services/<str:uid>/', api_views.ServiceRetrievalView.as_view(), name='service_retrieval'),
+
+    # path('api/<str:version>/namespaces/<str:namespace>/ingresses/', api_views.IngressCreationView.as_view(), name='ingress_creation'),
+    path('api/<str:version>/ingresses/<str:uid>/', api_views.IngressRetrievalView.as_view(), name='ingress_retrieval'),
 
     path('api/<str:version>/login/', dj_rest_views.LoginView.as_view(), name='rest_login'),
     path('api/<str:version>/logout/', dj_rest_views.LogoutView.as_view(), name='rest_logout'),
     path('api/<str:version>/login_google/', views.GoogleApiLoginView.as_view(), name='api_google_login'),
-    path('api/<str:version>/info/', api_views.InfoView.as_view(), name='info_overview'),
-    path('api/<str:version>/info/<str:info_slug>/', api_views.InfoDetailView.as_view(), name='info_detail'),
-    path('api/<str:version>/news/', api_views.NewsView.as_view(), name='news'),
 
     # frontend web auth views
     path('accounts/', include('allauth.urls')),

--- a/kubeportal/urls.py
+++ b/kubeportal/urls.py
@@ -66,7 +66,7 @@ urlpatterns = [
     path('api/<str:version>/namespaces/<str:namespace>/services/', api_views.ServiceCreationView.as_view(), name='service_creation'),
     path('api/<str:version>/services/<str:uid>/', api_views.ServiceRetrievalView.as_view(), name='service_retrieval'),
 
-    # path('api/<str:version>/namespaces/<str:namespace>/ingresses/', api_views.IngressCreationView.as_view(), name='ingress_creation'),
+    path('api/<str:version>/namespaces/<str:namespace>/ingresses/', api_views.IngressCreationView.as_view(), name='ingress_creation'),
     path('api/<str:version>/ingresses/<str:uid>/', api_views.IngressRetrievalView.as_view(), name='ingress_retrieval'),
 
     path('api/<str:version>/login/', dj_rest_views.LoginView.as_view(), name='rest_login'),


### PR DESCRIPTION
This pull requests combines the following results:

- All Swagger API docs are now correct and consistent. This is realized with a major re-factoring of the serializer and view logic. Closes #154 
- Naming was unified, e.g. "/info" -> "/infos". Please check if the endpoints in the frontend code are still correct.
- The endpoint for a single namespace now returns a single "listing" URL per Kubernetes resource, which then allows to fetch the complete list. This was implemented for services, pods, deployments, and ingresses. Closes #151.
- Some missing GET endpoints for resources are now implemented. I forgot which one were missing.
- API calls now always return dictionaries.
- Dictionary fields containing a URL now show this in their name. This makes some work for the frontend code (sorry), but makes the documentation much more readable.

