### PR TITLE
Approval API endpoints / fix for news author problem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,4 +64,4 @@ deployment/k8s/dashboard/ingress.yml
 db.sqlite3
 kubeportal/secret_key.txt
 devinit.sh
-.idea/workspace.xml
+workspace.xml

--- a/kubeportal/api/views/users.py
+++ b/kubeportal/api/views/users.py
@@ -125,7 +125,7 @@ class UserApprovalView(generics.RetrieveAPIView, generics.CreateAPIView):
             })
             return Response(instance.data)
         else:
-            logger.error(f"User {request.user} is not allowed to fetch the approval status fpr user id {user_id}.")
+            logger.error(f"User {request.user} is not allowed to fetch the approval status for user id {user_id}.")
             raise NotFound
 
     @extend_schema(

--- a/kubeportal/tests/test_api_news.py
+++ b/kubeportal/tests/test_api_news.py
@@ -1,4 +1,5 @@
 import json
+from urllib.parse import urlparse
 
 from django.conf import settings
 
@@ -15,3 +16,20 @@ def test_news_list(api_client, admin_user):
     assert "<p>Hello World</p>" == data[0]["content"]
     assert "Foo" == data[0]["title"]
     assert data[0]["author_url"].endswith(f"/{admin_user.pk}/")
+
+def test_foreign_news_author(api_client, admin_user, second_user):
+    test_news = News(content="<p>Hello World</p>", title="Foo", author=second_user)
+    test_news.save()
+
+    response = api_client.get(f'/api/{settings.API_VERSION}/news/')
+    assert response.status_code == 200
+    data = json.loads(response.content)
+
+    relative_author_url = urlparse(data[0]['author_url']).path
+    response = api_client.get(relative_author_url)
+    assert response.status_code == 200
+    data = json.loads(response.text)
+    assert len(data.keys()) == 3
+    assert 'k8s_token' not in data.keys()
+    assert 'firstname' in data.keys()
+    assert data['firstname'] == second_user.first_name

--- a/kubeportal/tests/test_api_users.py
+++ b/kubeportal/tests/test_api_users.py
@@ -96,8 +96,12 @@ def test_user_invalid_id(api_client):
 
 def test_get_user_not_himself(api_client, second_user):
     response = api_client.get(f'/api/{settings.API_VERSION}/users/{second_user.pk}/')
-    assert response.status_code == 404
-
+    assert response.status_code == 200
+    data = json.loads(response.text)
+    assert len(data.keys()) == 3
+    assert 'k8s_token' not in data.keys()
+    assert 'firstname' in data.keys()
+    assert data['firstname'] == second_user.first_name
 
 def test_no_general_user_list(api_client):
     response = api_client.get(f'/api/{settings.API_VERSION}/users/')

--- a/kubeportal/urls.py
+++ b/kubeportal/urls.py
@@ -53,6 +53,7 @@ urlpatterns = [
     path('api/<str:version>/serviceaccounts/<str:uid>/', api_views.ServiceAccountRetrievalView.as_view(), name='serviceaccount_retrieval'),
 
     path('api/<str:version>/users/<int:user_id>/', api_views.UserView.as_view(), name='user'),
+    path('api/<str:version>/users/<int:user_id>/approval/', api_views.UserApprovalView.as_view(), name='user_approval'),
     path('api/<str:version>/groups/<int:group_id>/', api_views.GroupView.as_view(), name='group'),
     path('api/<str:version>/webapps/<int:webapp_id>/', api_views.WebAppView.as_view(), name='webapplication'),
     path('api/<str:version>/infos/', api_views.InfoView.as_view(), name='info_overview'),


### PR DESCRIPTION
This pull request implements the approval end points (closes #149). It also modifies the behavior of the user details endpoint, which now gives limited information (first name / last name only) when you requested information about somebody not being you. The latter patch closes #159, and allows to return the list of approval admins as URLs.