### PR TITLE
Fix Ingress / PVC API endpoints

### DIFF
--- a/deployment/k8s/base/rbac.yml
+++ b/deployment/k8s/base/rbac.yml
@@ -4,14 +4,20 @@ metadata:
   name: kubeportal-api-access
 rules:
 - apiGroups: [""]
-  resources: ["secrets","serviceaccounts","namespaces"]
+  resources: ["namespaces","persistentvolumeclaims", "pods", "deployments", "services"]
   verbs: ["get","list","watch","create"]
+- apiGroups: [""]
+  resources: ["secrets","serviceaccounts"]
+  verbs: ["get","list","watch"]
 - apiGroups: ["rbac.authorization.k8s.io"]
   resources: ["rolebindings"]
   verbs: ["get","list","watch","create"]
 - apiGroups: ["rbac.authorization.k8s.io"]
   resources: ["clusterroles"]
   verbs: ["bind"]
+- apiGroups: ["networking.k8s.io"]
+  resources: ["ingresses"]
+  verbs: ["get","list","watch","create"]
 ---
 # This must be a CLusterRoleBinding, so that all namespaces
 # can be modified

--- a/kubeportal/tests/fixtures/ingress1.yml
+++ b/kubeportal/tests/fixtures/ingress1.yml
@@ -1,7 +1,7 @@
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
-  name: test-ingress-1b
+  name: test-ingress-1
   namespace: default
   annotations:
     foo: bar

--- a/kubeportal/tests/test_api_persistentvolumeclaims.py
+++ b/kubeportal/tests/test_api_persistentvolumeclaims.py
@@ -68,3 +68,17 @@ def test_pvc_create(api_client, admin_user):
         assert len(pvcs) > 0
     finally:
         api.core_v1.delete_namespaced_persistent_volume_claim(name="test-pvc", namespace="default")
+
+
+@pytest.mark.skipif(minikube_unavailable(), reason="Minikube is unavailable")
+def test_empty_pvc_list(api_client, admin_user_with_k8s):
+    response = api_client.get(f'/api/{settings.API_VERSION}/namespaces/default/')
+    assert 200 == response.status_code
+    data = json.loads(response.content)
+    from urllib.parse import urlparse
+    pvcs_url = urlparse(data['persistentvolumeclaims_url'])
+
+    response = api_client.get(pvcs_url.path)
+    assert 200 == response.status_code
+    data = json.loads(response.content)
+    assert len(data['persistentvolumeclaim_urls']) == 0


### PR DESCRIPTION
The Ingress / PVC API endpoints did not work since the permissions for Kubeportal were not sufficient in our production environment. This patch updates the deployment files.

Hint: The patch is already applied for the Data Science cluster.