### PR TITLE
API Performance Tuning

### DIFF
--- a/kubeportal/api/views/__init__.py
+++ b/kubeportal/api/views/__init__.py
@@ -14,6 +14,13 @@ General design principles:
 - Data structures are always described as DRF serializers, even when
   they are not really used in their original sense. This again enables
   the correct work of drf-spectacular for the API doc generation.
+- For uncached Kubernetes resources, we do not use the native UIDs,
+  but a self-created portal identifier ("puid"),
+  which is a concatenation of namespace and
+  resource name with an illegal character in K8S, but not in URL world.
+  This allows us to fetch a single pod / deployment / ... in the most
+  efficient manner, since field selectors for the K8S metadata UID are
+  not supported in the K8S API.
 """
 
 from .bootstrapinfo import *

--- a/kubeportal/k8s/kubernetes_api.py
+++ b/kubeportal/k8s/kubernetes_api.py
@@ -225,19 +225,22 @@ def get_pods():
         return None
 
 
-def get_pod(uid):
+def get_namespaced_pod(namespace, name):
+    try:
+        return core_v1.read_namespaced_pod(name, namespace)
+    except Exception as e:
+        logger.exception(f"Error while fetching pod {namespace}:{name}")
+        return None
+
+def get_namespaced_pods(namespace):
     """
-    Get pod in the cluster by its uid.
+    Get all pods for a specific Kubernetes namespace in the cluster.
     """
     try:
-        pods = get_pods()
-        for pod in pods:
-            if pod.metadata.uid == uid:
-                return pod
-        return None
+        return core_v1.list_namespaced_pod(namespace).items
     except Exception as e:
-        logger.exception(f"Error while fetching pod with uid {uid}")
-        return None
+        logger.exception(f"Error while fetching pods of namespace {namespace}")
+        return []
 
 
 def get_ingresses():
@@ -251,26 +254,11 @@ def get_ingresses():
         return None
 
 
-def get_ingress(uid):
+def get_namespaced_ingress(namespace, name):
     """
-    Get ingress in the cluster by its uid.
+    Get ingress in the cluster.
     """
-    ingresses = get_ingresses()
-    for ingress in ingresses:
-        if ingress.metadata.uid == uid:
-            return ingress
-    return None
-
-
-def get_namespaced_pods(namespace):
-    """
-    Get all pods for a specific Kubernetes namespace in the cluster.
-    """
-    try:
-        return core_v1.list_namespaced_pod(namespace).items
-    except Exception as e:
-        logger.exception(f"Error while fetching pods of namespace {namespace}")
-        return []
+    return net_v1.read_namespaced_ingress(name, namespace)
 
 
 def get_namespaced_deployments(namespace):
@@ -309,16 +297,12 @@ def get_deployments():
         return None
 
 
-def get_deployment(uid):
+def get_namespaced_deployment(namespace, name):
     """
-    Get deployment in the cluster by its uid.
+    Get deployment in the cluster by its namespace and name.
     """
     try:
-        deployments = get_deployments()
-        for deployment in deployments:
-            if deployment.metadata.uid == uid:
-                return deployment
-        return None
+        return apps_v1.read_namespaced_deployment(name, namespace)
     except Exception as e:
         logger.exception(f"Error while fetching deployment with uid {uid}")
         return None
@@ -335,18 +319,14 @@ def get_services():
         return None
 
 
-def get_service(uid):
+def get_namespaced_service(namespace, name):
     """
-    Get service in the cluster by its uid.
+    Get service in the cluster.
     """
     try:
-        services = get_services()
-        for service in services:
-            if service.metadata.uid == uid:
-                return service
-        return None
+        return core_v1.read_namespaced_service(name, namespace)
     except Exception as e:
-        logger.exception(f"Error while fetching service with uid {uid}")
+        logger.exception(f"Error while fetching service.")
         return None
 
 
@@ -381,18 +361,14 @@ def get_pvcs():
         logger.exception("Error while fetching list of all pvcs from Kubernetes")
         return None
 
-def get_pvc(uid):
+def get_namespaced_pvc(namespace, name):
     """
-    Get pvc in the cluster by its uid.
+    Get pvc in the cluster.
     """
     try:
-        pvcs = get_pvcs()
-        for pvc in pvcs:
-            if pvc.metadata.uid == uid:
-                return pvc
-        return None
+        return core_v1.read_namespaced_persistent_volume_claim(name, namespace)
     except Exception as e:
-        logger.exception(f"Error while fetching persistent volume claim with uid {uid}")
+        logger.exception(f"Error while fetching persistent volume claim.")
         return None
 
 

--- a/kubeportal/tests/test_api_deployments.py
+++ b/kubeportal/tests/test_api_deployments.py
@@ -58,12 +58,12 @@ def test_get_illegal_deployment(api_client, admin_user):
 
     admin_user.service_account = default_namespace.service_accounts.all()[0]
     admin_user.save()
-    response = api_client.get(f'/api/{settings.API_VERSION}/deployments/{deployment.metadata.uid}/')
+    response = api_client.get(f'/api/{settings.API_VERSION}/deployments/{deployment.metadata.namespace}_{deployment.metadata.name}/')
     assert 404 == response.status_code
 
     admin_user.service_account = system_namespace.service_accounts.all()[0]
     admin_user.save()
-    response = api_client.get(f'/api/{settings.API_VERSION}/deployments/{deployment.metadata.uid}/')
+    response = api_client.get(f'/api/{settings.API_VERSION}/deployments/{deployment.metadata.namespace}_{deployment.metadata.name}/')
     assert 200 == response.status_code
 
 
@@ -76,10 +76,10 @@ def test_deployment(api_client, admin_user):
 
     admin_user.service_account = system_namespace.service_accounts.all()[0]
     admin_user.save()
-    response = api_client.get(f'/api/{settings.API_VERSION}/deployments/{deployment.metadata.uid}/')
+    response = api_client.get(f'/api/{settings.API_VERSION}/deployments/{deployment.metadata.namespace}_{deployment.metadata.name}/')
     assert 200 == response.status_code
     data = json.loads(response.content)
-    assert 'uid' in data.keys()
+    assert 'puid' in data.keys()
     assert 'name' in data.keys()
     assert 'creation_timestamp' in data.keys()
     assert 'replicas' in data.keys()

--- a/kubeportal/tests/test_api_ingresses.py
+++ b/kubeportal/tests/test_api_ingresses.py
@@ -200,7 +200,7 @@ def test_empty_user_ingresses_list(api_client, admin_user_with_k8s):
     assert len(data['ingress_urls']) == 0
 
 def test_broken_k8s_single_ingress(api_client, admin_user_with_k8s, mocker):
-    mocker.patch('kubeportal.k8s.kubernetes_api.get_ingress', side_effect=Exception())
+    mocker.patch('kubeportal.k8s.kubernetes_api.get_namespaced_ingress', side_effect=Exception())
     apply_k8s_yml(BASE_DIR + "fixtures/ingress1.yml")
 
     try:

--- a/kubeportal/tests/test_api_pods.py
+++ b/kubeportal/tests/test_api_pods.py
@@ -48,7 +48,7 @@ def test_get_pod(api_client, admin_user):
 
     pod = api.core_v1.read_namespaced_pod(test_pod_name, 'kube-system')
 
-    response = api_client.get(f'/api/{settings.API_VERSION}/pods/{pod.metadata.uid}/')
+    response = api_client.get(f'/api/{settings.API_VERSION}/pods/{pod.metadata.namespace}_{pod.metadata.name}/')
     assert 200 == response.status_code
     data = json.loads(response.content)
     assert data['name'] == test_pod_name
@@ -75,7 +75,7 @@ def test_get_illegal_pod(api_client, admin_user):
 
     pod = api.core_v1.read_namespaced_pod(test_pod_name, 'kube-system')
 
-    response = api_client.get(f'/api/{settings.API_VERSION}/pods/{pod.metadata.uid}/')
+    response = api_client.get(f'/api/{settings.API_VERSION}/pods/{pod.metadata.namespace}_{pod.metadata.name}/')
     assert 404 == response.status_code
 
 

--- a/kubeportal/urls.py
+++ b/kubeportal/urls.py
@@ -45,11 +45,11 @@ urlpatterns = [
     path('api/<str:version>/namespaces/<str:namespace>/pods/', api_views.PodsView.as_view(), name='pods'),
     path('api/<str:version>/namespaces/<str:namespace>/services/', api_views.ServicesView.as_view(), name='services'),
 
-    path('api/<str:version>/deployments/<str:uid>/', api_views.DeploymentRetrievalView.as_view(), name='deployment_retrieval'),
-    path('api/<str:version>/ingresses/<str:uid>/', api_views.IngressRetrievalView.as_view(), name='ingress_retrieval'),
-    path('api/<str:version>/persistentvolumeclaims/<str:uid>/', api_views.PersistentVolumeClaimRetrievalView.as_view(), name='pvc_retrieval'),
-    path('api/<str:version>/pods/<str:uid>/', api_views.PodRetrievalView.as_view(), name='pod_retrieval'),
-    path('api/<str:version>/services/<str:uid>/', api_views.ServiceRetrievalView.as_view(), name='service_retrieval'),
+    path('api/<str:version>/deployments/<str:puid>/', api_views.DeploymentRetrievalView.as_view(), name='deployment_retrieval'),
+    path('api/<str:version>/ingresses/<str:puid>/', api_views.IngressRetrievalView.as_view(), name='ingress_retrieval'),
+    path('api/<str:version>/persistentvolumeclaims/<str:puid>/', api_views.PersistentVolumeClaimRetrievalView.as_view(), name='pvc_retrieval'),
+    path('api/<str:version>/pods/<str:puid>/', api_views.PodRetrievalView.as_view(), name='pod_retrieval'),
+    path('api/<str:version>/services/<str:puid>/', api_views.ServiceRetrievalView.as_view(), name='service_retrieval'),
     path('api/<str:version>/serviceaccounts/<str:uid>/', api_views.ServiceAccountRetrievalView.as_view(), name='serviceaccount_retrieval'),
 
     path('api/<str:version>/users/<int:user_id>/', api_views.UserView.as_view(), name='user'),


### PR DESCRIPTION
This patch should speedup the API calls that fetch Kubernetes resources directly, e.g. /pods/<uid> and /deployments/<uid>. There is no visible change in the API, only the UIDs are formulated in a different way and therefore called "PUID" in such cases.
